### PR TITLE
feat: support direct principals

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,8 +59,8 @@ func main() {
 
 	rootCmd := &cobra.Command{
 		Use:   os.Args[0],
-		Short: os.Args[0] + " is an open-source implementation of GKE Workload Identity",
-		Long:  os.Args[0] + " is an open-source implementation of GKE Workload Identity for non-GKE Kubernetes clusters",
+		Short: os.Args[0] + " is an open-source implementation of GCP Workload Identity Federation for GKE",
+		Long:  os.Args[0] + " is an open-source implementation of GCP Workload Identity Federation for GKE for non-GKE Kubernetes clusters",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logLevel, err := logrus.ParseLevel(stringLogLevel)
 			if err != nil {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -69,8 +69,8 @@ func newServerCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "server",
-		Short: "Start the GKE Workload Identity emulator",
-		Long:  "Start the GKE Workload Identity emulator for serving requests locally inside each node of the Kubernes cluster",
+		Short: "Start the GKE Metadata Server emulator",
+		Long:  "Start the GKE Metadata Server emulator for serving requests locally inside each node of the Kubernes cluster",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			// validate input
 			nodeName := os.Getenv("NODE_NAME")
@@ -87,7 +87,7 @@ func newServerCommand() *cobra.Command {
 				Name:      defaultNodeServiceAccountName,
 				Namespace: defaultNodeServiceAccountNamespace,
 			}
-			googleCredentialsConfig, err := googlecredentials.NewConfig(googlecredentials.ConfigOptions{
+			googleCredentialsConfig, workloadIdentityPool, err := googlecredentials.NewConfig(googlecredentials.ConfigOptions{
 				WorkloadIdentityProvider: workloadIdentityProvider,
 			})
 			if err != nil {
@@ -220,12 +220,14 @@ func newServerCommand() *cobra.Command {
 				ServiceAccountTokens:      serviceAccountTokens,
 				MetricsRegistry:           metricsRegistry,
 				DefaultNodeServiceAccount: defaultNodeServiceAccount,
+				WorkloadIdentityPool:      workloadIdentityPool,
 			})
 
 			webhookServer := webhook.New(ctx, webhook.ServerOptions{
 				ServerAddr:       webhookAddr,
 				InitNetworkImage: webhookInitNetworkImage,
 				DaemonSetPort:    strings.Split(serverAddr, ":")[1],
+				MetricsRegistry:  metricsRegistry,
 			})
 
 			ctx, cancel := waitForShutdown(ctx)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -47,11 +47,6 @@ import (
 )
 
 func newServerCommand() *cobra.Command {
-	const (
-		metricsSubsystem       = ""   // empty since metrics.Namespace already ends with "server"
-		tokenExpirationSeconds = 3600 // 1h
-	)
-
 	var (
 		serverAddr                          string
 		webhookAddr                         string
@@ -93,7 +88,6 @@ func newServerCommand() *cobra.Command {
 				Namespace: defaultNodeServiceAccountNamespace,
 			}
 			googleCredentialsConfig, err := googlecredentials.NewConfig(googlecredentials.ConfigOptions{
-				TokenExpirationSeconds:   tokenExpirationSeconds,
 				WorkloadIdentityProvider: workloadIdentityProvider,
 			})
 			if err != nil {
@@ -126,12 +120,11 @@ func newServerCommand() *cobra.Command {
 			var wp *watchpods.Provider
 			if watchPods {
 				opts := watchpods.ProviderOptions{
-					FallbackSource:   pods,
-					NodeName:         nodeName,
-					MetricsSubsystem: metricsSubsystem,
-					KubeClient:       kubeClient,
-					MetricsRegistry:  metricsRegistry,
-					ResyncPeriod:     watchPodsResyncPeriod,
+					FallbackSource:  pods,
+					NodeName:        nodeName,
+					KubeClient:      kubeClient,
+					MetricsRegistry: metricsRegistry,
+					ResyncPeriod:    watchPodsResyncPeriod,
 				}
 				if watchPodsDisableFallback {
 					opts.FallbackSource = nil
@@ -170,11 +163,10 @@ func newServerCommand() *cobra.Command {
 			var wsa *watchserviceaccounts.Provider
 			if watchServiceAccounts {
 				opts := watchserviceaccounts.ProviderOptions{
-					FallbackSource:   serviceAccounts,
-					MetricsSubsystem: metricsSubsystem,
-					KubeClient:       kubeClient,
-					MetricsRegistry:  metricsRegistry,
-					ResyncPeriod:     watchServiceAccountsResyncPeriod,
+					FallbackSource:  serviceAccounts,
+					KubeClient:      kubeClient,
+					MetricsRegistry: metricsRegistry,
+					ResyncPeriod:    watchServiceAccountsResyncPeriod,
 				}
 				if watchServiceAccountsDisableFallback {
 					opts.FallbackSource = nil
@@ -191,11 +183,10 @@ func newServerCommand() *cobra.Command {
 			})
 			if cacheTokens {
 				p := cacheserviceaccounttokens.NewProvider(ctx, cacheserviceaccounttokens.ProviderOptions{
-					Source:           serviceAccountTokens,
-					ServiceAccounts:  serviceAccounts,
-					MetricsSubsystem: metricsSubsystem,
-					MetricsRegistry:  metricsRegistry,
-					Concurrency:      cacheTokensConcurrency,
+					Source:          serviceAccountTokens,
+					ServiceAccounts: serviceAccounts,
+					MetricsRegistry: metricsRegistry,
+					Concurrency:     cacheTokensConcurrency,
 				})
 				defer p.Close()
 				if wp != nil {
@@ -223,7 +214,6 @@ func newServerCommand() *cobra.Command {
 			s := server.New(ctx, server.ServerOptions{
 				NodeName:                  nodeName,
 				ServerAddr:                serverAddr,
-				MetricsSubsystem:          metricsSubsystem,
 				Pods:                      pods,
 				Node:                      node,
 				ServiceAccounts:           serviceAccounts,

--- a/internal/googlecredentials/google_credentials.go
+++ b/internal/googlecredentials/google_credentials.go
@@ -37,7 +37,6 @@ type (
 	}
 
 	ConfigOptions struct {
-		TokenExpirationSeconds   int
 		WorkloadIdentityProvider string
 	}
 )
@@ -72,9 +71,6 @@ func (c *Config) Get(ctx context.Context, googleServiceAccountEmail, credFile st
 		"service_account_impersonation_url": fmt.Sprintf(
 			"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
 			googleServiceAccountEmail),
-		"service_account_impersonation": map[string]any{
-			"token_lifetime_seconds": c.TokenExpirationSeconds(),
-		},
 	}
 
 	b, err := json.Marshal(conf)
@@ -90,8 +86,4 @@ func (c *Config) Get(ctx context.Context, googleServiceAccountEmail, credFile st
 
 func (c *Config) WorkloadIdentityProviderAudience() string {
 	return fmt.Sprintf("//iam.googleapis.com/%s", c.opts.WorkloadIdentityProvider)
-}
-
-func (c *Config) TokenExpirationSeconds() int {
-	return c.opts.TokenExpirationSeconds
 }

--- a/internal/http/status.go
+++ b/internal/http/status.go
@@ -22,38 +22,4 @@
 
 package pkghttp
 
-import "net/http"
-
-const (
-	StatusClientClosedRequest = 499
-)
-
-type StatusRecorder struct {
-	http.ResponseWriter
-	statusCode        int
-	writeHeaderCalled bool
-}
-
-func (s *StatusRecorder) Write(b []byte) (int, error) {
-	if !s.writeHeaderCalled {
-		s.WriteHeader(s.StatusCode())
-	}
-	return s.ResponseWriter.Write(b)
-}
-
-func (s *StatusRecorder) WriteHeader(statusCode int) {
-	s.statusCode = statusCode
-	s.writeHeaderCalled = true
-	s.ResponseWriter.WriteHeader(statusCode)
-}
-
-func (s *StatusRecorder) StatusCode() int {
-	if !s.writeHeaderCalled {
-		return http.StatusOK
-	}
-	return s.statusCode
-}
-
-func (s *StatusRecorder) WriteHeaderCalled() bool {
-	return s.writeHeaderCalled
-}
+const StatusClientClosedRequest = 499

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -50,10 +50,9 @@ func HandlerFor(registry *prometheus.Registry, l promhttp.Logger) http.Handler {
 	})
 }
 
-func NewLatencyMillis(subsystem string, labelNames []string) *prometheus.HistogramVec {
+func NewLatencyMillis(labelNames []string) *prometheus.HistogramVec {
 	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
-		Subsystem: subsystem,
 		Name:      "request_latency_millis",
 		Buckets:   prometheus.ExponentialBuckets(0.2, 5, 7),
 	}, labelNames)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -50,9 +50,10 @@ func HandlerFor(registry *prometheus.Registry, l promhttp.Logger) http.Handler {
 	})
 }
 
-func NewLatencyMillis(labelNames []string) *prometheus.HistogramVec {
+func NewLatencyMillis(subsystem string, labelNames ...string) *prometheus.HistogramVec {
 	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
+		Subsystem: subsystem,
 		Name:      "request_latency_millis",
 		Buckets:   prometheus.ExponentialBuckets(0.2, 5, 7),
 	}, labelNames)

--- a/internal/pods/watch/provider.go
+++ b/internal/pods/watch/provider.go
@@ -53,12 +53,11 @@ type (
 	}
 
 	ProviderOptions struct {
-		NodeName         string
-		MetricsSubsystem string
-		FallbackSource   pods.Provider
-		KubeClient       *kubernetes.Clientset
-		MetricsRegistry  *prometheus.Registry
-		ResyncPeriod     time.Duration
+		NodeName        string
+		FallbackSource  pods.Provider
+		KubeClient      *kubernetes.Clientset
+		MetricsRegistry *prometheus.Registry
+		ResyncPeriod    time.Duration
 	}
 
 	Listener interface {
@@ -72,14 +71,12 @@ const ipIndex = "ip"
 func NewProvider(opts ProviderOptions) *Provider {
 	numPods := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: opts.MetricsSubsystem,
 		Name:      "pods",
 		Help:      "Amount of Pod objects currently cached.",
 	})
 	opts.MetricsRegistry.MustRegister(numPods)
 	cacheMisses := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: opts.MetricsSubsystem,
 		Name:      "pod_cache_misses_total",
 		Help:      "Total amount cache misses when looking up Pod objects.",
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,7 +53,6 @@ type (
 	ServerOptions struct {
 		NodeName                  string
 		ServerAddr                string
-		MetricsSubsystem          string
 		Pods                      pods.Provider
 		Node                      node.Provider
 		ServiceAccounts           serviceaccounts.Provider
@@ -78,12 +77,11 @@ const (
 )
 
 func New(ctx context.Context, opts ServerOptions) *Server {
-	latencyMillis := metrics.NewLatencyMillis(opts.MetricsSubsystem, []string{"method", "path", "status"})
+	latencyMillis := metrics.NewLatencyMillis([]string{"method", "path", "status"})
 	opts.MetricsRegistry.MustRegister(latencyMillis)
 
 	lookupPodFailures := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: opts.MetricsSubsystem,
 		Name:      "lookup_pod_failures_total",
 		Help:      "Total failures when looking up Pod objects by IP to serve requests.",
 	}, []string{"client_ip"})
@@ -91,7 +89,6 @@ func New(ctx context.Context, opts ServerOptions) *Server {
 
 	getNodeFailures := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: opts.MetricsSubsystem,
 		Name:      "get_node_failures_total",
 		Help:      "Total failures when getting the current Node object to serve requests.",
 	})

--- a/internal/serviceaccounts/helpers.go
+++ b/internal/serviceaccounts/helpers.go
@@ -36,10 +36,7 @@ type Reference struct {
 	Namespace string `json:"namespace"`
 }
 
-var (
-	ErrGKEAnnotationMissing = fmt.Errorf("gke annotation %q missing", gkeAnnotation)
-	ErrGKEAnnotationInvalid = fmt.Errorf("gke annotation %q has invalid google service account email", gkeAnnotation)
-)
+var ErrGKEAnnotationInvalid = fmt.Errorf("gke annotation %q has invalid google service account email", gkeAnnotation)
 
 const (
 	gkeAnnotation = "iam.gke.io/gcp-service-account"
@@ -98,18 +95,18 @@ func ReferenceFromToken(token string) *Reference {
 }
 
 // GoogleEmail returns the Google service account email from the same annotation
-// used in native GKE Workload Identity. The annotation is:
+// used in native GCP Workload Identity Federation for GKE. The annotation is:
 //
 // iam.gke.io/gcp-service-account
-func GoogleEmail(sa *corev1.ServiceAccount) (string, error) {
+func GoogleEmail(sa *corev1.ServiceAccount) (*string, error) {
 	v, ok := sa.Annotations[gkeAnnotation]
 	if !ok {
-		return "", ErrGKEAnnotationMissing
+		return nil, nil
 	}
 	if !googleEmailRegex.MatchString(v) {
-		return "", ErrGKEAnnotationInvalid
+		return nil, ErrGKEAnnotationInvalid
 	}
-	return v, nil
+	return &v, nil
 }
 
 func getServiceAccountReference(m map[string]string) *Reference {

--- a/internal/serviceaccounts/watch/provider.go
+++ b/internal/serviceaccounts/watch/provider.go
@@ -50,11 +50,10 @@ type (
 	}
 
 	ProviderOptions struct {
-		MetricsSubsystem string
-		FallbackSource   serviceaccounts.Provider
-		KubeClient       *kubernetes.Clientset
-		MetricsRegistry  *prometheus.Registry
-		ResyncPeriod     time.Duration
+		FallbackSource  serviceaccounts.Provider
+		KubeClient      *kubernetes.Clientset
+		MetricsRegistry *prometheus.Registry
+		ResyncPeriod    time.Duration
 	}
 
 	Listener interface {
@@ -66,14 +65,12 @@ type (
 func NewProvider(ctx context.Context, opts ProviderOptions) *Provider {
 	numServiceAccounts := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: opts.MetricsSubsystem,
 		Name:      "service_accounts",
 		Help:      "Amount of ServiceAccount objects currently cached.",
 	})
 	opts.MetricsRegistry.MustRegister(numServiceAccounts)
 	cacheMisses := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: opts.MetricsSubsystem,
 		Name:      "service_account_cache_misses_total",
 		Help:      "Total amount cache misses when looking up ServiceAccount objects.",
 	})

--- a/internal/serviceaccounttokens/cache/provider.go
+++ b/internal/serviceaccounttokens/cache/provider.go
@@ -130,7 +130,7 @@ func (p *Provider) GetServiceAccountToken(ctx context.Context, ref *serviceaccou
 	return token.token, token.expiration(), nil
 }
 
-func (p *Provider) GetGoogleAccessToken(ctx context.Context, saToken, googleEmail string) (string, time.Time, error) {
+func (p *Provider) GetGoogleAccessToken(ctx context.Context, saToken string, googleEmail *string) (string, time.Time, error) {
 	ref := serviceaccounts.ReferenceFromToken(saToken)
 	tokens, err := p.getTokens(ctx, ref)
 	if err != nil {
@@ -217,6 +217,12 @@ func (p *Provider) cacheTokens(sa *serviceAccount) (retErr error) {
 		// release semaphore
 		<-p.semaphore
 
+		// enhance logging with google service account email if any
+		l := l
+		if email != nil {
+			l = l.WithField("google_service_account", *email)
+		}
+
 		// check if service account was deleted again since it may take some time to create tokens
 		if deleted := p.checkIfMustDeleteAndDelete(sa); deleted {
 			return errServiceAccountDeleted
@@ -226,17 +232,11 @@ func (p *Provider) cacheTokens(sa *serviceAccount) (retErr error) {
 		var sleepDuration time.Duration
 		if err != nil {
 			// do not retry invalid GKE annotation errors
-			annotationMissing := errors.Is(err, serviceaccounts.ErrGKEAnnotationMissing)
-			annotationInvalid := errors.Is(err, serviceaccounts.ErrGKEAnnotationInvalid)
-			if annotationMissing || annotationInvalid {
+			if errors.Is(err, serviceaccounts.ErrGKEAnnotationInvalid) {
 				sleepDuration = 10 * 365 * 24 * time.Hour // infinite
 				retries = 0
 				sendResponse(&tokensAndError{err: err})
-				if annotationMissing {
-					l.Debug("service account does not have GKE annotation, sleeping for a long time...")
-				} else {
-					l.WithError(err).Error("service account has invalid GKE annotation, will not retry")
-				}
+				l.WithError(err).Error("service account has invalid GKE annotation, will not retry")
 			} else { // retry any other error
 				sleepDuration = (1 << retries) * time.Second
 				if retries < 5 {
@@ -253,7 +253,7 @@ func (p *Provider) cacheTokens(sa *serviceAccount) (retErr error) {
 			}
 			retries = 0
 			sendResponse(&tokensAndError{tokens: tokens})
-			l.WithField("google_service_account", email).Info("cached tokens for service account")
+			l.Info("cached tokens for service account")
 		}
 
 		// store tokens

--- a/internal/serviceaccounttokens/cache/provider.go
+++ b/internal/serviceaccounttokens/cache/provider.go
@@ -53,11 +53,10 @@ type Provider struct {
 }
 
 type ProviderOptions struct {
-	Source           serviceaccounttokens.Provider
-	ServiceAccounts  serviceaccounts.Provider
-	MetricsSubsystem string
-	MetricsRegistry  *prometheus.Registry
-	Concurrency      int
+	Source          serviceaccounttokens.Provider
+	ServiceAccounts serviceaccounts.Provider
+	MetricsRegistry *prometheus.Registry
+	Concurrency     int
 }
 
 var errServiceAccountDeleted = errors.New("service account was deleted")
@@ -65,14 +64,12 @@ var errServiceAccountDeleted = errors.New("service account was deleted")
 func NewProvider(ctx context.Context, opts ProviderOptions) *Provider {
 	numTokens := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: opts.MetricsSubsystem,
 		Name:      "service_account_tokens",
 		Help:      "Amount of ServiceAccount tokens currently cached.",
 	})
 	opts.MetricsRegistry.MustRegister(numTokens)
 	cacheMisses := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: opts.MetricsSubsystem,
 		Name:      "service_account_token_cache_misses_total",
 		Help:      "Total amount cache misses when fetching ServiceAccount tokens.",
 	})

--- a/internal/serviceaccounttokens/cache/tokens.go
+++ b/internal/serviceaccounttokens/cache/tokens.go
@@ -52,25 +52,25 @@ type googleIDTokenReference struct {
 	audience               string
 }
 
-func (p *Provider) createTokens(ctx context.Context, saRef *serviceaccounts.Reference) (*tokens, string, error) {
+func (p *Provider) createTokens(ctx context.Context, saRef *serviceaccounts.Reference) (*tokens, *string, error) {
 	sa, err := p.opts.ServiceAccounts.Get(ctx, saRef)
 	if err != nil {
-		return nil, "", fmt.Errorf("error getting kubernetes service account: %w", err)
+		return nil, nil, fmt.Errorf("error getting kubernetes service account: %w", err)
 	}
 
 	email, err := serviceaccounts.GoogleEmail(sa)
 	if err != nil {
-		return nil, "", fmt.Errorf("error getting google service account from kubernetes service account: %w", err)
+		return nil, nil, fmt.Errorf("error getting google service account from kubernetes service account: %w", err)
 	}
 
 	saToken, saTokenExpiration, err := p.opts.Source.GetServiceAccountToken(ctx, saRef)
 	if err != nil {
-		return nil, "", fmt.Errorf("error creating token for kubernetes service account: %w", err)
+		return nil, nil, fmt.Errorf("error creating token for kubernetes service account: %w", err)
 	}
 
 	accessToken, accessTokenExpiration, err := p.opts.Source.GetGoogleAccessToken(ctx, saToken, email)
 	if err != nil {
-		return nil, "", fmt.Errorf("error creating access token for google service account %s: %w", email, err)
+		return nil, nil, fmt.Errorf("error creating google access token: %w", err)
 	}
 
 	return &tokens{

--- a/internal/serviceaccounttokens/create/provider.go
+++ b/internal/serviceaccounttokens/create/provider.go
@@ -73,7 +73,7 @@ func (p *Provider) GetServiceAccountToken(ctx context.Context, ref *serviceaccou
 	return status.Token, status.ExpirationTimestamp.Time, nil
 }
 
-func (p *Provider) GetGoogleAccessToken(ctx context.Context, saToken, googleEmail string) (string, time.Time, error) {
+func (p *Provider) GetGoogleAccessToken(ctx context.Context, saToken string, googleEmail *string) (string, time.Time, error) {
 	var token *oauth2.Token
 	err := p.runWithGoogleCredentialsFromKubernetesServiceAccountToken(ctx, saToken, googleEmail, func(ctx context.Context, c *google.Credentials) (err error) {
 		token, err = c.TokenSource.Token()
@@ -87,7 +87,7 @@ func (p *Provider) GetGoogleAccessToken(ctx context.Context, saToken, googleEmai
 
 func (p *Provider) GetGoogleIdentityToken(ctx context.Context, saToken, googleEmail, audience string) (string, time.Time, error) {
 	var token *oauth2.Token
-	err := p.runWithGoogleCredentialsFromKubernetesServiceAccountToken(ctx, saToken, googleEmail, func(ctx context.Context, c *google.Credentials) (err error) {
+	err := p.runWithGoogleCredentialsFromKubernetesServiceAccountToken(ctx, saToken, &googleEmail, func(ctx context.Context, c *google.Credentials) (err error) {
 		source, err := idtoken.NewTokenSource(ctx, audience, option.WithCredentials(c))
 		if err != nil {
 			return err
@@ -109,7 +109,7 @@ func (p *Provider) GetGoogleIdentityToken(ctx context.Context, saToken, googleEm
 // file. The temporary file is removed before the function
 // returns (hence why a callback is used).
 func (p *Provider) runWithGoogleCredentialsFromKubernetesServiceAccountToken(ctx context.Context,
-	token, email string, f func(context.Context, *google.Credentials) error) error {
+	token string, email *string, f func(context.Context, *google.Credentials) error) error {
 	// write k8s sa token to tmp file
 	file, err := os.CreateTemp("/tmp", "*.json")
 	if err != nil {
@@ -123,7 +123,7 @@ func (p *Provider) runWithGoogleCredentialsFromKubernetesServiceAccountToken(ctx
 	}
 
 	// get the credential config with k8s sa token file as the credential source
-	creds, err := p.opts.GoogleCredentialsConfig.Get(ctx, email, tokenFile)
+	creds, err := p.opts.GoogleCredentialsConfig.Get(ctx, tokenFile, email)
 	if err != nil {
 		return err
 	}

--- a/internal/serviceaccounttokens/create/provider.go
+++ b/internal/serviceaccounttokens/create/provider.go
@@ -57,15 +57,13 @@ func NewProvider(opts ProviderOptions) serviceaccounttokens.Provider {
 }
 
 func (p *Provider) GetServiceAccountToken(ctx context.Context, ref *serviceaccounts.Reference) (string, time.Time, error) {
-	expSecs := int64(p.opts.GoogleCredentialsConfig.TokenExpirationSeconds())
 	tokenRequest, err := p.opts.
 		KubeClient.
 		CoreV1().
 		ServiceAccounts(ref.Namespace).
 		CreateToken(ctx, ref.Name, &authnv1.TokenRequest{
 			Spec: authnv1.TokenRequestSpec{
-				Audiences:         []string{p.opts.GoogleCredentialsConfig.WorkloadIdentityProviderAudience()},
-				ExpirationSeconds: &expSecs,
+				Audiences: []string{p.opts.GoogleCredentialsConfig.WorkloadIdentityProviderAudience()},
 			},
 		}, metav1.CreateOptions{})
 	if err != nil {

--- a/internal/serviceaccounttokens/provider.go
+++ b/internal/serviceaccounttokens/provider.go
@@ -31,6 +31,6 @@ import (
 
 type Provider interface {
 	GetServiceAccountToken(ctx context.Context, ref *serviceaccounts.Reference) (string, time.Time, error)
-	GetGoogleAccessToken(ctx context.Context, saToken, googleEmail string) (string, time.Time, error)
+	GetGoogleAccessToken(ctx context.Context, saToken string, googleEmail *string) (string, time.Time, error)
 	GetGoogleIdentityToken(ctx context.Context, saToken, googleEmail, audience string) (string, time.Time, error)
 }

--- a/k8s/test-pod.yaml
+++ b/k8s/test-pod.yaml
@@ -20,20 +20,35 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+
 # This file is not only a core part of our test automation in this project,
 # but also an example of how to configure Pods in a cluster where the emulator
 # is deployed. Use this as reference for how to configure your production Pods.
 
-# ServiceAccount configuration is the exact same of Workload Identity in GKE.
+
+# ServiceAccount configuration is the exact same of Workload Identity Federation for GKE.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-impersonated
+  namespace: default
+  annotations:
+    # If you want to impersonate a GCP Service Account, you must set this annotation.
+    # Impersonation is required for using the Identity API (to get Google OIDC Tokens
+    # for the impersonated GCP Service Account):
+    #   GET /computeMetadata/v1/instance/service-accounts/default/identity
+    iam.gke.io/gcp-service-account: test-sa@gke-metadata-server.iam.gserviceaccount.com
+---
+# If you are granting direct resource access, the annotation is not needed. Some GCP
+# may have limitations and not support direct resource access. See docs:
+#   * https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#use-wlif
+#   * https://cloud.google.com/iam/docs/federated-identity-supported-services#list
+# The Identity API is not supported by this method.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test
   namespace: default
-  annotations:
-    # This annotation is how Workload Identity is configured in GKE.
-    # This project uses the same annotation to know which Google Service Account to impersonate.
-    iam.gke.io/gcp-service-account: test-sa@gke-metadata-server.iam.gserviceaccount.com
 ---
 apiVersion: v1
 kind: Pod
@@ -47,9 +62,11 @@ metadata:
     # outbound traffic targeting 169.254.169.254:80 to the emulator port on the Node.
     gke-metadata-server.matheuscscp.io/webhook: Mutate
 spec:
-  serviceAccountName: test # Use the ServiceAccount created above.
+  serviceAccountName: <SERVICE_ACCOUNT> # Use the ServiceAccount created above.
 
-  # ATTENTION: All the configuration below is test-only and not needed in production!
+  ################################################################################
+  # Note: All the configuration below is test-only and not needed in production. #
+  ################################################################################
 
   restartPolicy: Never
   hostNetwork: <HOST_NETWORK>

--- a/terraform/ci.tf
+++ b/terraform/ci.tf
@@ -71,15 +71,6 @@ resource "google_project_iam_custom_role" "continuous_integration" {
   permissions = ["iam.workloadIdentityPoolProviders.create"]
 }
 
-resource "google_storage_bucket_iam_binding" "ci_cluster_issuer_creators" {
-  bucket = local.cluster_issuer_bucket
-  role   = "roles/storage.objectCreator"
-  members = [
-    google_service_account.pull_request.member,
-    google_service_account.release.member,
-  ]
-}
-
 resource "google_project_iam_member" "resource_cleaner" {
   project = local.project
   role    = google_project_iam_custom_role.resource_cleaner.name

--- a/terraform/test.tf
+++ b/terraform/test.tf
@@ -24,20 +24,8 @@
 # https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes
 
 locals {
-  cluster_issuer_bucket = "gke-metadata-server-issuer-test"
-  test_bucket           = "gke-metadata-server-test"
-  principal_prefix      = "principal://iam.googleapis.com/${google_iam_workload_identity_pool.test_kind_cluster.name}/subject/system:serviceaccount"
-}
-
-resource "google_storage_bucket" "cluster_issuer_test" {
-  name     = local.cluster_issuer_bucket
-  location = "us"
-}
-
-resource "google_storage_bucket_iam_member" "all_users_object_viewer" {
-  bucket = google_storage_bucket.cluster_issuer_test.name
-  role   = "roles/storage.objectViewer"
-  member = "allUsers"
+  test_bucket      = "gke-metadata-server-test"
+  principal_prefix = "principal://iam.googleapis.com/${google_iam_workload_identity_pool.test_kind_cluster.name}/subject/system:serviceaccount"
 }
 
 resource "google_iam_workload_identity_pool" "test_kind_cluster" {
@@ -67,9 +55,14 @@ resource "google_service_account_iam_member" "openid_token_creator" {
 }
 
 resource "google_storage_bucket" "test" {
-  name                     = local.test_bucket
-  location                 = "us"
-  public_access_prevention = "enforced"
+  name                        = local.test_bucket
+  location                    = "us"
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true # required for direct resource access
+
+  soft_delete_policy {
+    retention_duration_seconds = 0
+  }
 
   lifecycle_rule {
     action {

--- a/timoni/gke-metadata-server/templates/settings.cue
+++ b/timoni/gke-metadata-server/templates/settings.cue
@@ -35,7 +35,7 @@ import (
 	// defaultNodeServiceAccount is an optional Google Service Account email to add on the gke-metadata-server
 	// ServiceAccount annotation. The emulator will use this ServiceAccount for Pods running on the host network
 	// in case the Node where they are running does on not specify a ServiceAccount in the annotations (see README.md).
-	defaultNodeServiceAccount?: string & =~"^.+@.+$"
+	defaultNodeServiceAccount?: string & =~"^[a-zA-Z0-9-]+@[a-zA-Z0-9-]+\\.iam\\.gserviceaccount\\.com$"
 
 	// logLevel is the log level for gke-metadata-server.
 	logLevel?: string & ("panic" | "fatal" | "error" | "warning" | "info" | "debug" | "trace")

--- a/versions.yaml
+++ b/versions.yaml
@@ -20,6 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-helm: 0.10.0
-timoni: 0.10.0
-container: 0.10.0
+helm: 0.11.0
+timoni: 0.11.0
+container: 0.11.0


### PR DESCRIPTION
GKE Workload Identity was renamed to GCP Workload Identity Federation for GKE and now it supports granting permissions to principals that directly represent the Kubernetes ServiceAccounts (with some limitations):

https://cloud.google.com/blog/products/identity-security/make-iam-for-gke-easier-to-use-with-workload-identity-federation