### PR TITLE
fix: load config before attaching redirect ebpf program to hook

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -20,6 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-helm: 0.13.0
-timoni: 0.13.0
-container: 0.13.0
+helm: 0.13.1
+timoni: 0.13.1
+container: 0.13.1


### PR DESCRIPTION
Probably not an issue since we guard against a nil config in the eBPF code, but logically it makes more sense to load the config first and then attach.