### PR TITLE
feat: add support for gcloud cli

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -49,6 +49,7 @@ import (
 func newServerCommand() *cobra.Command {
 	var (
 		serverPort                          int
+		projectID                           string
 		workloadIdentityProvider            string
 		nodePoolServiceAccountName          string
 		nodePoolServiceAccountNamespace     string
@@ -98,7 +99,7 @@ func newServerCommand() *cobra.Command {
 					Namespace: nodePoolServiceAccountNamespace,
 				}
 			}
-			googleCredentialsConfig, workloadIdentityPool, err := googlecredentials.NewConfig(googlecredentials.ConfigOptions{
+			googleCredentialsConfig, numericProjectID, workloadIdentityPool, err := googlecredentials.NewConfig(googlecredentials.ConfigOptions{
 				WorkloadIdentityProvider: workloadIdentityProvider,
 			})
 			if err != nil {
@@ -235,6 +236,8 @@ func newServerCommand() *cobra.Command {
 				ServiceAccountTokens:   serviceAccountTokens,
 				MetricsRegistry:        metricsRegistry,
 				NodePoolServiceAccount: nodePoolServiceAccount,
+				ProjectID:              projectID,
+				NumericProjectID:       numericProjectID,
 				WorkloadIdentityPool:   workloadIdentityPool,
 			})
 
@@ -250,6 +253,8 @@ func newServerCommand() *cobra.Command {
 
 	cmd.Flags().IntVar(&serverPort, "server-port", 8080,
 		"Network address where the metadata server must listen on")
+	cmd.Flags().StringVar(&projectID, "project-id", "",
+		"Project ID of the GCP project where the GCP Workload Identity Provider is configured")
 	cmd.Flags().StringVar(&workloadIdentityProvider, "workload-identity-provider", "",
 		"Mandatory fully-qualified resource name of the GCP Workload Identity Provider (projects/<project_number>/locations/global/workloadIdentityPools/<pool_name>/providers/<provider_name>)")
 	cmd.Flags().StringVar(&nodePoolServiceAccountName, "node-pool-service-account-name", "",

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -43,6 +43,7 @@ type emulator struct {
 
 type pod struct {
 	name               string
+	file               string
 	serviceAccountName string
 	hostNetwork        bool
 	nodePool           nodePool
@@ -123,6 +124,15 @@ func TestEndToEnd(t *testing.T) {
 				},
 				{
 					name:               "test-direct-access",
+					serviceAccountName: "test",
+					nodePool: nodePool{
+						name:      "gke-metadata-server",
+						namespace: "kube-system",
+					},
+				},
+				{
+					name:               "test-gcloud",
+					file:               "pod-gcloud.yaml",
 					serviceAccountName: "test",
 					nodePool: nodePool{
 						name:      "gke-metadata-server",
@@ -278,7 +288,11 @@ func applyPods(t *testing.T, pods []pod) {
 
 		// execute pod template
 		var pod string
-		b, err := os.ReadFile("testdata/pod.yaml")
+		file := "pod.yaml"
+		if p.file != "" {
+			file = p.file
+		}
+		b, err := os.ReadFile("testdata/" + file)
 		require.NoError(t, err)
 		serviceAccountName := "default"
 		if sa := p.serviceAccountName; sa != "" {

--- a/helm/gke-metadata-server/templates/daemonset.yaml
+++ b/helm/gke-metadata-server/templates/daemonset.yaml
@@ -85,6 +85,7 @@ spec:
           privileged: true
         args:
         - server
+        - --project-id={{ .Values.config.projectID }}
         - --workload-identity-provider={{ .Values.config.workloadIdentityProvider }}
         {{- if (.Values.config.nodePool | default dict).enable }}
         - --node-pool-service-account-name={{ .Release.Name }}

--- a/helm/gke-metadata-server/values.yaml
+++ b/helm/gke-metadata-server/values.yaml
@@ -25,6 +25,8 @@
 # Declare variables to be passed into your templates.
 
 config:
+  # Mandatory GCP project ID.
+  projectID: ""
   # Mandatory fully-qualified name of the GCP Workload Identity Provider.
   # This full name can be retrieved on the Google Cloud Console webpage for the provider.
   # Must match the pattern: projects/<gcp_project_number>/locations/global/workloadIdentityPools/<pool_name>/providers/<provider_name>

--- a/internal/googlecredentials/google_credentials.go
+++ b/internal/googlecredentials/google_credentials.go
@@ -41,7 +41,7 @@ type (
 	}
 )
 
-var workloadIdentityProviderRegex = regexp.MustCompile(`^projects/\d+/locations/global/workloadIdentityPools/([^/]+)/providers/[^/]+$`)
+var workloadIdentityProviderRegex = regexp.MustCompile(`^projects/(\d+)/locations/global/workloadIdentityPools/([^/]+)/providers/[^/]+$`)
 
 func AccessScopes() []string {
 	return []string{
@@ -50,13 +50,14 @@ func AccessScopes() []string {
 	}
 }
 
-func NewConfig(opts ConfigOptions) (*Config, string, error) {
+func NewConfig(opts ConfigOptions) (*Config, string, string, error) {
 	if !workloadIdentityProviderRegex.MatchString(opts.WorkloadIdentityProvider) {
-		return nil, "", fmt.Errorf("workload identity provider name does not match pattern %s",
+		return nil, "", "", fmt.Errorf("workload identity provider name does not match pattern %s",
 			workloadIdentityProviderRegex.String())
 	}
-	workloadIdentityPool := workloadIdentityProviderRegex.FindStringSubmatch(opts.WorkloadIdentityProvider)[1]
-	return &Config{opts}, workloadIdentityPool, nil
+	numericProjectID := workloadIdentityProviderRegex.FindStringSubmatch(opts.WorkloadIdentityProvider)[1]
+	workloadIdentityPool := workloadIdentityProviderRegex.FindStringSubmatch(opts.WorkloadIdentityProvider)[2]
+	return &Config{opts}, numericProjectID, workloadIdentityPool, nil
 }
 
 func (c *Config) Get(ctx context.Context, credFile string, googleServiceAccountEmail *string) (*google.Credentials, error) {

--- a/internal/http/response.go
+++ b/internal/http/response.go
@@ -86,7 +86,7 @@ func RespondJSON(w http.ResponseWriter, r *http.Request, statusCode int, obj any
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	setGKEMetadataServerHeaders(w, "application/json", statusCode)
 	w.WriteHeader(statusCode)
 	if n, err := w.Write(b); err != nil {
 		logging.
@@ -111,7 +111,7 @@ func RespondJSON(w http.ResponseWriter, r *http.Request, statusCode int, obj any
 }
 
 func RespondText(w http.ResponseWriter, r *http.Request, statusCode int, text string) {
-	w.Header().Set("Content-Type", "application/text")
+	setGKEMetadataServerHeaders(w, "application/text", statusCode)
 	w.WriteHeader(statusCode)
 	if n, err := w.Write([]byte(text)); err != nil {
 		logging.
@@ -129,6 +129,14 @@ func RespondText(w http.ResponseWriter, r *http.Request, statusCode int, text st
 	}
 
 	observeRequest(r, statusCode, nil)
+}
+
+func setGKEMetadataServerHeaders(w http.ResponseWriter, contentType string, statusCode int) {
+	w.Header().Set("Content-Type", contentType)
+	if 200 <= statusCode && statusCode < 300 {
+		w.Header().Set(metadataFlavorHeader, metadataFlavorGoogle)
+		w.Header().Set("Server", "GKE Metadata Server")
+	}
 }
 
 func responseLogFields(statusCode int, errResp ...any) logrus.Fields {

--- a/internal/server/gke_apis_test.go
+++ b/internal/server/gke_apis_test.go
@@ -179,7 +179,8 @@ func TestGKEServiceAccountIdentityAPI(t *testing.T) {
 Please add the iam.gke.io/gcp-service-account=[GSA_NAME]@[PROJECT_ID] annotation to your Kubernetes service account.
 Refer to https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 `
-		resp := requestURL(t, gkeHeaders, url, "application/text", gkeMetadataFlavor, http.StatusNotFound)
+		const expectedMetadataFlavor = ""
+		resp := requestURL(t, gkeHeaders, url, "application/text", expectedMetadataFlavor, http.StatusNotFound)
 		assert.Equal(t, expectedMsg, resp)
 		return
 	}

--- a/testdata/helm-values.yaml
+++ b/testdata/helm-values.yaml
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 config:
+  projectID: gke-metadata-server
   workloadIdentityProvider: projects/637293746831/locations/global/workloadIdentityPools/test-kind-cluster/providers/<TEST_ID>
 
 image:

--- a/testdata/pod-gcloud.yaml
+++ b/testdata/pod-gcloud.yaml
@@ -1,0 +1,64 @@
+# MIT License
+#
+# Copyright (c) 2025 Matheus Pimenta
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-gcloud
+  namespace: default
+spec:
+  serviceAccountName: <SERVICE_ACCOUNT>
+  hostAliases:
+  - hostnames: [metadata.google.internal]
+    ip: 169.254.169.254
+  restartPolicy: Never
+  containers:
+  - name: gcs
+    image: google/cloud-sdk:510.0.0-slim
+    command:
+    - sh
+    - -c
+    - |
+      # loop trying to create a new object in gs://gke-metadata-server-test with a random key and
+      # content until it succeeds, then read the object back. delete the object, and finally,
+      # if the content is different from the original, exit with an error code.
+      while true; do
+        key=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+        content=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+        echo $content > /tmp/$key
+        if gcloud storage cp /tmp/$key gs://gke-metadata-server-test/$key; then
+          break
+        fi
+      done
+      gcloud storage cat gs://gke-metadata-server-test/$key > /tmp/${key}.2
+      gcloud storage rm gs://gke-metadata-server-test/$key
+      cat <<EOF
+      Original content: $(cat /tmp/$key)
+      Downloaded content: $(cat /tmp/${key}.2)
+      EOF
+      if diff /tmp/$key /tmp/${key}.2; then
+        echo "Content match"
+        exit 0
+      fi
+      echo "Content mismatch"
+      exit 1
+<NODE_SELECTOR_AND_TOLERATIONS>

--- a/testdata/timoni-values-no-watch.cue
+++ b/testdata/timoni-values-no-watch.cue
@@ -23,6 +23,7 @@
 package main
 
 values: settings: {
+	projectID:                "gke-metadata-server"
 	workloadIdentityProvider: "projects/637293746831/locations/global/workloadIdentityPools/test-kind-cluster/providers/<TEST_ID>"
 	watchPods:                enable: false
 	watchNode:                enable: false

--- a/testdata/timoni-values-watch.cue
+++ b/testdata/timoni-values-watch.cue
@@ -23,10 +23,11 @@
 package main
 
 values: settings: {
-	workloadIdentityProvider:     "projects/637293746831/locations/global/workloadIdentityPools/test-kind-cluster/providers/<TEST_ID>"
-	watchPods:                    disableFallback: false
-	watchNode:                    disableFallback: false
-	watchServiceAccounts:         disableFallback: false
+	projectID:                "gke-metadata-server"
+	workloadIdentityProvider: "projects/637293746831/locations/global/workloadIdentityPools/test-kind-cluster/providers/<TEST_ID>"
+	watchPods:                disableFallback: false
+	watchNode:                disableFallback: false
+	watchServiceAccounts:     disableFallback: false
 	nodePool: {
 		enable:               true
 		googleServiceAccount: "test-sa@gke-metadata-server.iam.gserviceaccount.com"

--- a/timoni/gke-metadata-server/debug_values.cue
+++ b/timoni/gke-metadata-server/debug_values.cue
@@ -5,5 +5,6 @@ package main
 // Values used by debug_tool.cue.
 // Debug example 'cue cmd -t debug -t name=test -t namespace=test -t mv=1.0.0 -t kv=1.28.0 build'.
 values: settings: {
+	projectID:                "my-gcp-project-id"
 	workloadIdentityProvider: "projects/123456789012/locations/global/workloadIdentityPools/debug-pool/providers/debug-provider"
 }

--- a/timoni/gke-metadata-server/templates/daemonset.cue
+++ b/timoni/gke-metadata-server/templates/daemonset.cue
@@ -102,6 +102,7 @@ import (
 					}
 					args: [
 						"server",
+						"--project-id=\(#config.settings.projectID)",
 						"--workload-identity-provider=\(#config.settings.workloadIdentityProvider)",
 						if #config.settings.nodePool.enable {
 							"--node-pool-service-account-name=\(#config.metadata.name)"

--- a/timoni/gke-metadata-server/templates/settings.cue
+++ b/timoni/gke-metadata-server/templates/settings.cue
@@ -28,6 +28,9 @@ import (
 
 // #Settings is the schema for the gke-metadata-server application settings.
 #Settings: {
+	// projectID is the mandatory GCP project ID.
+	projectID: string
+
 	// workloadIdentityProvider is the mandatory fully-qualified name of the GCP Workload Identity Provider.
 	// This full name can be retrieved on the Google Cloud Console webpage for the provider.
 	workloadIdentityProvider: string & =~"^projects/\\d+/locations/global/workloadIdentityPools/[^/]+/providers/[^/]+$"

--- a/versions.yaml
+++ b/versions.yaml
@@ -20,6 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-helm: 0.14.0
-timoni: 0.14.0
-container: 0.14.0
+helm: 0.15.0
+timoni: 0.15.0
+container: 0.15.0


### PR DESCRIPTION
It turns out that for supporting the `gcloud` CLI the metadata server must serve a few more APIs beyond just `/token` and `/identity`. In particular, the `gcloud` CLI needs `/computeMetadata/v1/project/*` and `/computeMetadata/v1/instance/service-accounts/<email>/?recursive=true`. The latter is a JSON dump of the service account.

With this we can probably also close #24 since now we support a considerable set of APIs:

```go
const (
	gkeNodeNameAPI               = "/computeMetadata/v1/instance/name"
	gkeProjectIDAPI              = "/computeMetadata/v1/project/project-id"
	gkeNumericProjectIDAPI       = "/computeMetadata/v1/project/numeric-project-id"
	gkeServiceAccountsDirectory  = "/computeMetadata/v1/instance/service-accounts/$service_account"
	gkeServiceAccountAliasesAPI  = "/computeMetadata/v1/instance/service-accounts/$service_account/aliases"
	gkeServiceAccountEmailAPI    = "/computeMetadata/v1/instance/service-accounts/$service_account/email"
	gkeServiceAccountIdentityAPI = "/computeMetadata/v1/instance/service-accounts/$service_account/identity"
	gkeServiceAccountScopesAPI   = "/computeMetadata/v1/instance/service-accounts/$service_account/scopes"
	gkeServiceAccountTokenAPI    = "/computeMetadata/v1/instance/service-accounts/$service_account/token"
)
```

If any further APIs are needed we can open issues on a use-case basis.