### PR TITLE
Remove metadata.google.internal DNS record from Go tests

### DIFF
--- a/internal/server/gke_apis_test.go
+++ b/internal/server/gke_apis_test.go
@@ -56,7 +56,7 @@ var gkeHeaders = http.Header{
 }
 
 func TestGKEServiceAccountTokenAPI(t *testing.T) {
-	const url = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
+	const url = "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token"
 
 	var respBody struct {
 		AccessToken string `json:"access_token"`
@@ -186,7 +186,7 @@ func TestGKEServiceAccountIdentityAPI(t *testing.T) {
 	const expectedAudience = "test.com"
 	const expectedIssuer = "https://accounts.google.com"
 	const expectedSubject = `^\d{20,30}$`
-	const url = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=" + expectedAudience
+	const url = "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity?audience=" + expectedAudience
 
 	if os.Getenv("HOSTNAME") == "test-direct-access" {
 		const expectedMsg = `Your Kubernetes service account (default/test) is not annotated with a target Google service account, which is a requirement for retrieving Identity Tokens using Workload Identity.

--- a/testdata/pod.yaml
+++ b/testdata/pod.yaml
@@ -57,13 +57,6 @@ metadata:
   namespace: default
 spec:
   serviceAccountName: <SERVICE_ACCOUNT> # Use the ServiceAccount created above.
-  # This DNS record is required because the Google libraries hardcode the metadata server
-  # address as the hostname "metadata.google.internal". Sometimes they also hardcode the
-  # IP address. Sometimes they only hardcode the IP address, in which case this setting
-  # would not be needed. It all depends on what library your Pod is using. Test it!
-  hostAliases:
-  - hostnames: [metadata.google.internal]
-    ip: 169.254.169.254
 
   ################################################################################
   # Note: All the configuration below is test-only and not needed in production. #
@@ -71,7 +64,6 @@ spec:
 
   restartPolicy: Never
   hostNetwork: <HOST_NETWORK>
-  dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: test
     image: ghcr.io/matheuscscp/gke-metadata-server/test@<GO_TEST_DIGEST>


### PR DESCRIPTION
The Go library hardcodes the IP address. Removing the DNS record allows the Go tests to show that the emulator can run in environments with less custom configuration for Go code.