### PR TITLE
Add support for scopes to the Token API

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,10 @@ occupy port 80 in the network namespace of the Node.
 ### The `metadata.google.internal` DNS record
 
 Google has documented the `http://metadata.google.internal` endpoint as where to fetch
-metadata from. Some Google libraries may use this endpoint to fetch metadata from the
-emulator. If that's the case, you can configure your Pods with the following DNS
-configuration:
+metadata from, and that it should resolve to `http://169.254.169.254`. While some Google
+libraries hard-code the IP address and hit it directly without DNS resolution, others
+may use the DNS hostname to fetch metadata from the emulator. If that's your case, you
+can add to your Pods the following DNS configuration:
 
 ```yaml
 spec:
@@ -270,12 +271,6 @@ spec:
   - hostnames: [metadata.google.internal]
     ip: 169.254.169.254
 ```
-
-This IP address is also documented by Google as the address `metadata.google.internal`
-should resolve to. Not all Google libraries use the DNS hostname, some use this IP
-address directly in their code, so this configuration may not be necessary for all
-libraries (example: [Go](https://github.com/googleapis/google-cloud-go/blob/a961cb5e85ed07e2eaf088faa29ed9b60882212b/compute/metadata/metadata.go#L472-L485)).
-Pods running the `gcloud` CLI will require this configuration to work properly.
 
 ### Limitations and Security Risks
 

--- a/internal/googlecredentials/google_credentials.go
+++ b/internal/googlecredentials/google_credentials.go
@@ -66,13 +66,19 @@ func (c *Config) WorkloadIdentityProviderAudience() string {
 	return fmt.Sprintf("//iam.googleapis.com/%s", c.opts.WorkloadIdentityProvider)
 }
 
-func (c *Config) NewToken(ctx context.Context, subjectToken string, googleServiceAccountEmail *string) (*oauth2.Token, error) {
+func (c *Config) NewToken(ctx context.Context, subjectToken string,
+	googleServiceAccountEmail *string, scopes []string) (*oauth2.Token, error) {
+
+	if len(scopes) == 0 {
+		scopes = AccessScopes()
+	}
+
 	conf := externalaccount.Config{
 		UniverseDomain:       "googleapis.com",
 		Audience:             c.WorkloadIdentityProviderAudience(),
 		SubjectTokenType:     "urn:ietf:params:oauth:token-type:jwt",
 		TokenURL:             "https://sts.googleapis.com/v1/token",
-		Scopes:               AccessScopes(),
+		Scopes:               scopes,
 		SubjectTokenSupplier: tokenSupplier(subjectToken),
 	}
 

--- a/internal/server/gke_apis.go
+++ b/internal/server/gke_apis.go
@@ -105,7 +105,7 @@ Refer to https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identit
 		if err != nil {
 			return nil, err
 		}
-		accessTokens, _, r, err := s.getPodGoogleAccessTokens(w, r)
+		accessTokens, _, r, err := s.getPodGoogleAccessTokens(w, r, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -130,7 +130,13 @@ func (s *Server) gkeServiceAccountScopesAPI() pkghttp.MetadataHandlerFunc {
 
 func (s *Server) gkeServiceAccountTokenAPI() pkghttp.MetadataHandler {
 	mh := func(w http.ResponseWriter, r *http.Request) (any, error) {
-		tokens, expiresAt, _, err := s.getPodGoogleAccessTokens(w, r)
+		var scopes []string
+		for scope := range strings.SplitSeq(r.URL.Query().Get("scopes"), ",") {
+			if s := strings.TrimSpace(scope); s != "" {
+				scopes = append(scopes, s)
+			}
+		}
+		tokens, expiresAt, _, err := s.getPodGoogleAccessTokens(w, r, scopes)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/pods.go
+++ b/internal/server/pods.go
@@ -106,7 +106,7 @@ func (s *Server) listPodGoogleServiceAccounts(w http.ResponseWriter, r *http.Req
 // impersonation.
 // If there's an error this function sends the response to the client.
 func (s *Server) getPodGoogleAccessTokens(w http.ResponseWriter, r *http.Request,
-) (*serviceaccounttokens.AccessTokens, time.Time, *http.Request, error) {
+	scopes []string) (*serviceaccounttokens.AccessTokens, time.Time, *http.Request, error) {
 	saRef, r, err := s.getPodServiceAccountReference(w, r)
 	if err != nil {
 		return nil, time.Time{}, nil, err
@@ -122,7 +122,7 @@ func (s *Server) getPodGoogleAccessTokens(w http.ResponseWriter, r *http.Request
 		return nil, time.Time{}, nil, err
 	}
 	tokens, expiresAt, err := s.opts.ServiceAccountTokens.GetGoogleAccessTokens(
-		r.Context(), saToken, googleEmail)
+		r.Context(), saToken, googleEmail, scopes)
 	if err != nil {
 		respondGoogleAPIErrorf(w, r, "error getting google access token: %w", err)
 		return nil, time.Time{}, nil, err

--- a/internal/serviceaccounttokens/cache/tokens.go
+++ b/internal/serviceaccounttokens/cache/tokens.go
@@ -53,6 +53,12 @@ type googleIDTokenReference struct {
 	audience               string
 }
 
+type googleScopedAccessTokenReference struct {
+	serviceAccountRefernce serviceaccounts.Reference
+	email                  string
+	scopes                 string
+}
+
 func (p *Provider) createTokens(ctx context.Context, saRef *serviceaccounts.Reference) (*tokens, *string, error) {
 	sa, err := p.opts.ServiceAccounts.Get(ctx, saRef)
 	if err != nil {
@@ -69,7 +75,7 @@ func (p *Provider) createTokens(ctx context.Context, saRef *serviceaccounts.Refe
 		return nil, nil, fmt.Errorf("error creating token for kubernetes service account: %w", err)
 	}
 
-	accessTokens, accessTokenExpiration, err := p.opts.Source.GetGoogleAccessTokens(ctx, saToken, email)
+	accessTokens, accessTokenExpiration, err := p.opts.Source.GetGoogleAccessTokens(ctx, saToken, email, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating google access token: %w", err)
 	}

--- a/internal/serviceaccounttokens/provider.go
+++ b/internal/serviceaccounttokens/provider.go
@@ -36,7 +36,8 @@ type AccessTokens struct {
 
 type Provider interface {
 	GetServiceAccountToken(ctx context.Context, ref *serviceaccounts.Reference) (string, time.Time, error)
-	GetGoogleAccessTokens(ctx context.Context, saToken string, googleEmail *string) (*AccessTokens, time.Time, error)
+	GetGoogleAccessTokens(ctx context.Context, saToken string, googleEmail *string,
+		scopes []string) (*AccessTokens, time.Time, error)
 	GetGoogleIdentityToken(ctx context.Context, saRef *serviceaccounts.Reference,
 		accessToken, googleEmail, audience string) (string, time.Time, error)
 }

--- a/testdata/pod.yaml
+++ b/testdata/pod.yaml
@@ -57,6 +57,13 @@ metadata:
   namespace: default
 spec:
   serviceAccountName: <SERVICE_ACCOUNT> # Use the ServiceAccount created above.
+  # This DNS record is required because the Google libraries hardcode the metadata server
+  # address as the hostname "metadata.google.internal". Sometimes they also hardcode the
+  # IP address. Sometimes they only hardcode the IP address, in which case this setting
+  # would not be needed. It all depends on what library your Pod is using. Test it!
+  hostAliases:
+  - hostnames: [metadata.google.internal]
+    ip: 169.254.169.254
 
   ################################################################################
   # Note: All the configuration below is test-only and not needed in production. #
@@ -64,6 +71,7 @@ spec:
 
   restartPolicy: Never
   hostNetwork: <HOST_NETWORK>
+  dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: test
     image: ghcr.io/matheuscscp/gke-metadata-server/test@<GO_TEST_DIGEST>


### PR DESCRIPTION
Closes #384 

`GET /computeMetadata/v1/instance/service-accounts/default/token` now supports the `scopes` query parameter containing a list of comma-separated scopes.