### PR TITLE
Reduce pod timeout from 2 minutes to 1 minute

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -381,7 +381,7 @@ func waitForPods(t *testing.T, pods []pod) []int {
 
 	var exitCodes []int
 	for i, p := range pods {
-		const podTimeout = 2 * time.Minute
+		const podTimeout = time.Minute
 		const sleepSecs = 10
 		timeout := time.Now().Add(podTimeout)
 


### PR DESCRIPTION
## Summary
- Reduce pod completion timeout in tests from 2 minutes to 1 minute
- Helps tests fail faster while still providing adequate time for normal pod completion

## Test plan
- [x] Timeout value updated in main_test.go
- [ ] CI tests pass with new timeout

🤖 Generated with [Claude Code](https://claude.ai/code)