### PR TITLE
Improve token expiration logic with max duration and 80% rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,13 @@ kubectl delete pods -l app=gke-metadata-server -n kube-system
 
 New Pods will be created by the DaemonSet and they will not have the cached tokens.
 
-Tokens usually expire in at most one hour.
+The emulator implements an 80% refresh rule (similar to kubelet for ServiceAccount token
+rotation) and supports configurable maximum token duration limits. The 80% rule means
+tokens are refreshed when they have consumed 80% of their original lifetime. The maximum
+token duration setting allows capping the effective duration of cached tokens (default: 1 hour).
+This can be configured through the Helm Chart and Timoni Module values APIs.
+
+With the default configuration, tokens expire in at most one hour.
 
 ## Disclaimer
 

--- a/helm/gke-metadata-server/templates/daemonset.yaml
+++ b/helm/gke-metadata-server/templates/daemonset.yaml
@@ -104,6 +104,9 @@ spec:
         {{- if .Values.config.cacheTokens.concurrency }}
         - --cache-tokens-concurrency={{ .Values.config.cacheTokens.concurrency }}
         {{- end }}
+        {{- if .Values.config.cacheTokens.maxTokenDuration }}
+        - --cache-max-token-duration={{ .Values.config.cacheTokens.maxTokenDuration }}
+        {{- end }}
         {{- end }}
         env:
         - name: NODE_NAME

--- a/helm/gke-metadata-server/values.yaml
+++ b/helm/gke-metadata-server/values.yaml
@@ -49,6 +49,7 @@ config:
   cacheTokens:
     enable: true # Whether or not to proactively cache tokens for the Service Accounts used by the Pods running in the same Node.
     concurrency: 10 # Maximum parallel caching operations.
+    maxTokenDuration: 1h # Maximum duration for cached service account tokens.
 
 podAnnotations: {}
   # Optionally, configure Prometheus to scrape the server:

--- a/internal/server/gke_apis_test.go
+++ b/internal/server/gke_apis_test.go
@@ -315,7 +315,7 @@ func requestURL(t *testing.T, headers http.Header, url, expectedContentType,
 
 func assertExpirationSeconds(t *testing.T, secs int) {
 	t.Helper()
-	assert.LessOrEqual(t, 3000, secs)
+	assert.LessOrEqual(t, 2400, secs)
 	assert.LessOrEqual(t, secs, 3700)
 }
 

--- a/internal/serviceaccounttokens/cache/provider.go
+++ b/internal/serviceaccounttokens/cache/provider.go
@@ -56,10 +56,11 @@ type Provider struct {
 }
 
 type ProviderOptions struct {
-	Source          serviceaccounttokens.Provider
-	ServiceAccounts serviceaccounts.Provider
-	MetricsRegistry *prometheus.Registry
-	Concurrency     int
+	Source           serviceaccounttokens.Provider
+	ServiceAccounts  serviceaccounts.Provider
+	MetricsRegistry  *prometheus.Registry
+	Concurrency      int
+	MaxTokenDuration time.Duration
 }
 
 var errServiceAccountDeleted = errors.New("service account was deleted")
@@ -197,7 +198,7 @@ func (p *Provider) GetGoogleAccessTokens(ctx context.Context, saToken string,
 	if tokenString == "" {
 		tokenString = tokens.Impersonated
 	}
-	token = newToken(tokenString, expiration)
+	token = newToken(tokenString, expiration, p.opts.MaxTokenDuration)
 	p.googleScopedAccessTokensMutex.Lock()
 	p.googleScopedAccessTokens[ref] = token
 	p.googleScopedAccessTokensMutex.Unlock()
@@ -237,7 +238,7 @@ func (p *Provider) GetGoogleIdentityToken(ctx context.Context, saRef *serviceacc
 	}
 
 	// token issued successfully. cache it and return
-	token = newToken(tokenString, expiration)
+	token = newToken(tokenString, expiration, p.opts.MaxTokenDuration)
 	p.googleIDTokensMutex.Lock()
 	p.googleIDTokens[ref] = token
 	p.googleIDTokensMutex.Unlock()

--- a/timoni/gke-metadata-server/templates/daemonset.cue
+++ b/timoni/gke-metadata-server/templates/daemonset.cue
@@ -109,6 +109,9 @@ import (
 						if #config.settings.cacheTokens.enable && #config.settings.cacheTokens.concurrency != _|_ {
 							"--cache-tokens-concurrency=\(#config.settings.cacheTokens.concurrency)"
 						}
+						if #config.settings.cacheTokens.enable && #config.settings.cacheTokens.maxTokenDuration != _|_ {
+							"--cache-max-token-duration=\(#config.settings.cacheTokens.maxTokenDuration)"
+						}
 					]
 					env: [
 						{

--- a/timoni/gke-metadata-server/templates/settings.cue
+++ b/timoni/gke-metadata-server/templates/settings.cue
@@ -60,6 +60,9 @@ import (
 
 		// concurrency is the number of concurrent workers to cache the GCP tokens.
 		concurrency?: int & >0
+
+		// maxTokenDuration is the maximum duration for cached service account tokens.
+		maxTokenDuration?: time.Duration
 	}
 
 	// Helper definitions.


### PR DESCRIPTION
## Summary
- Add configurable `--cache-max-token-duration` flag with 1 hour default
- Implement 80% refresh rule (applied first, similar to kubelet)
- Apply maximum duration limit after 80% rule (capped at 1 hour)
- Update Helm chart and Timoni module configuration
- Update documentation for new token expiration behavior

Resolves #346

🤖 Generated with [Claude Code](https://claude.ai/code)