### PR TITLE
fix(ci): install linux-tools-azure for bpftool on Ubuntu 24.04 runners

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -44,4 +44,4 @@ runs:
   - name: Install dependencies
     shell: bash
     run: |
-      sudo apt-get update && sudo apt-get install -y clang llvm bpfcc-tools libbpf-dev
+      sudo apt-get update && sudo apt-get install -y clang llvm bpfcc-tools libbpf-dev linux-tools-azure


### PR DESCRIPTION
GitHub Actions runners have migrated to Azure infrastructure running Ubuntu 24.04 with Azure-specific kernels (6.14.0-1012-azure). The bpftool binary is not available in the default packages and requires the linux-tools-azure package to be installed.

This fixes the CI failure:
  WARNING: bpftool not found for kernel 6.14.0-1012-azure

Added linux-tools-azure package to the ci-setup dependencies to ensure bpftool is available for eBPF code generation.

Generated with [Claude Code](https://claude.com/claude-code)