### PR TITLE
Use Google distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,9 @@ RUN go generate ./internal/redirect
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o gke-metadata-server \
     github.com/matheuscscp/gke-metadata-server
 
-FROM alpine:3.22
+FROM gcr.io/distroless/static:latest
 
 COPY --from=builder /app/gke-metadata-server .
+COPY LICENSE .
 
 ENTRYPOINT ["./gke-metadata-server"]


### PR DESCRIPTION
Migrate from Alpine to Google's distroless base images for improved security and supply chain provenance. This reduces the attack surface by removing package managers, shells, and unnecessary utilities from the production image.

Changes:
- Replace alpine:3.22 with gcr.io/distroless/static:nonroot in Dockerfile
- Add LICENSE file to production image
- Maintain static linking (CGO_ENABLED=0) and stripped binaries

Closes: #273