### PR TITLE
eBPF: Proxy connections not targeting the emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ install-cilium:
 		--set image.pullPolicy=IfNotPresent \
 		--set ipam.mode=kubernetes
 
+.PHONY: build-dev
+build-dev:
+	docker build . -t ${TEST_IMAGE}:${TAG} --push
+
 .PHONY: build
 build:
 	docker build . -t ${TEST_IMAGE}:container

--- a/ebpf/redirect.c
+++ b/ebpf/redirect.c
@@ -26,12 +26,12 @@
 #include <bpf/bpf_endian.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
-#include <bpf/bpf_helpers.h>
 
 // IPv4 family
 #define AF_INET 2
 
 struct Config {
+	__u32 emulator_pid;
 	__u32 emulator_ip;
 	__u16 emulator_port;
 	__u16 debug;
@@ -48,7 +48,7 @@ struct {
 // the GKE metadata server to the emulator.
 SEC("cgroup/connect4")
 int redirect_connect4(struct bpf_sock_addr *ctx) {
-	// We only care about IPv4 TCP connections
+	// We only care about IPv4 TCP connections.
 	if (ctx->user_family != AF_INET || ctx->protocol != IPPROTO_TCP) {
 		return 1;
 	}
@@ -56,12 +56,17 @@ int redirect_connect4(struct bpf_sock_addr *ctx) {
 	const __u32 dst = bpf_ntohl(ctx->user_ip4);
 	const __u32 dst_port = bpf_ntohs(ctx->user_port);
 
-	// 0xA9FEA9FE is 169.254.169.254, the GKE Metadata Server IP address
-	if (dst != 0xA9FEA9FE || dst_port != 80) {
+	// 0xA9FEA9FE is 169.254.169.254, the GKE Metadata Server IP address.
+	// 0xA9FEC4F5 is 169.254.196.245, the IP address we chose for
+	// self-discovery of the emulator PID, and 12345 is the port.
+	// If the connection is not targeting either of these addresses,
+	// do nothing, just allow it.
+	if (!(dst == 0xA9FEA9FE && dst_port == 80) && !(dst == 0xA9FEC4F5 && dst_port == 12345)) {
 		return 1;
 	}
 
-	// Fetch emulator configuration
+	// Fetch emulator configuration. If not found, log an error
+	// and allow the connection without redirection.
 	const __u32 key = 0;
 	struct Config *conf = bpf_map_lookup_elem(&map_config, &key);
 	if (!conf) {
@@ -69,16 +74,40 @@ int redirect_connect4(struct bpf_sock_addr *ctx) {
 		return 1;
 	}
 
-	// Redirect the connection to the emulator
-	ctx->user_ip4 = bpf_htonl(conf->emulator_ip);
-	ctx->user_port = bpf_htons(conf->emulator_port);
+	// Get the PID of the current process.
+	const __u64 pid_tgid = bpf_get_current_pid_tgid();
+	const __u32 pid = pid_tgid >> 32;
 
-	if (conf->debug) {
-		const __u32 emu = ctx->user_ip4;
-		bpf_printk("Redirecting connection to %pI4:%d", &emu, conf->emulator_port);
+	// If the emulator PID is 0 and the connection is targeting the self-discovery
+	// address, store the current PID as the emulator PID and block the connection.
+	if (conf->emulator_pid == 0) {
+		if (dst == 0xA9FEC4F5 && dst_port == 12345) {
+			conf->emulator_pid = pid;
+			if (conf->debug) {
+				bpf_printk("Discovered emulator PID: %d", pid);
+			}
+			return 0; // Block the connection.
+		}
+		bpf_printk("Error: redirect_connect4 called before emulator PID discovery");
+		return 1;
 	}
 
-	return 1;
+	// If the connection is coming from the emulator process, allow it without redirection.
+	if (pid == conf->emulator_pid) {
+		if (conf->debug) {
+			bpf_printk("Not redirecting connection from emulator process (PID: %d)", pid);
+		}
+		return 1;
+	}
+
+	// Redirect the connection to the emulator.
+	ctx->user_ip4 = bpf_htonl(conf->emulator_ip);
+	ctx->user_port = bpf_htons(conf->emulator_port);
+	if (conf->debug) {
+		const __u32 emu = ctx->user_ip4;
+		bpf_printk("Redirecting connection to emulator on %pI4:%d", &emu, conf->emulator_port);
+	}
+	return 1; // Allow the connection after redirection.
 }
 
 char __LICENSE[] SEC("license") = "GPL";

--- a/helm/gke-metadata-server/values.yaml
+++ b/helm/gke-metadata-server/values.yaml
@@ -32,8 +32,8 @@ config:
   # Must match the pattern: projects/<gcp_project_number>/locations/global/workloadIdentityPools/<pool_name>/providers/<provider_name>
   workloadIdentityProvider: ""
   logLevel: info # Log level. Accepted values: panic, fatal, error, warning, info, debug, trace
-  serverPort: 8080 # TCP port where the metadata HTTP server will listen on.
-  healthPort: 8081 # TCP port where the health HTTP server will listern on.
+  serverPort: 16321 # TCP port where the metadata HTTP server will listen on.
+  healthPort: 16322 # TCP port where the health HTTP server will listern on.
   watchPods:
     enable: true # Whether or not to watch and cache the Pods running on the same Node.
     disableFallback: false # Whether or not to disable the simple fallback method for looking up Pods upon cache misses.
@@ -54,7 +54,7 @@ config:
 podAnnotations: {}
   # Optionally, configure Prometheus to scrape the server:
   # prometheus.io/scrape: "true"
-  # prometheus.io/port: "8080"
+  # prometheus.io/port: "16321"
   # prometheus.io/path: /metrics
 
 resources: {}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -31,7 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const Namespace = "gke_metadata_server"
+const namespace = "gke_metadata_server"
 
 var processStartTime = time.Now()
 
@@ -50,11 +50,92 @@ func HandlerFor(registry *prometheus.Registry, l promhttp.Logger) http.Handler {
 	})
 }
 
-func NewLatencyMillis(subsystem string, labelNames ...string) *prometheus.HistogramVec {
+func NewRequestLatencyMillis() *prometheus.HistogramVec {
 	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: Namespace,
-		Subsystem: subsystem,
+		Namespace: namespace,
 		Name:      "request_latency_millis",
 		Buckets:   prometheus.ExponentialBuckets(0.2, 5, 7),
-	}, labelNames)
+	}, []string{"method", "path", "status"})
+}
+
+func NewLookupPodFailuresCounter() *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "lookup_pod_failures_total",
+		Help:      "Total failures when looking up Pod objects by IP to serve requests.",
+	}, []string{"client_ip"})
+}
+
+func NewGetNodeFailuresCounter() prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "get_node_failures_total",
+		Help:      "Total failures when getting the current Node object to serve requests.",
+	})
+}
+
+func NewProxyDialLantencyMillis() *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Subsystem: "proxy",
+		Name:      "dial_latency_millis",
+		Buckets:   prometheus.ExponentialBuckets(0.2, 5, 7),
+	}, []string{"client_ip"})
+}
+
+func NewProxyActiveConnectionsGauge() prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "proxy",
+		Name:      "active_connections",
+		Help:      "Current number of active connections being proxied.",
+	})
+}
+
+func NewCachedPodsGauge() prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "pods",
+		Help:      "Amount of Pod objects currently cached.",
+	})
+}
+
+func NewPodCacheMissesCounter() prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "pod_cache_misses_total",
+		Help:      "Total amount cache misses when looking up Pod objects.",
+	})
+}
+
+func NewCachedServiceAccountsGauge() prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "service_accounts",
+		Help:      "Amount of ServiceAccount objects currently cached.",
+	})
+}
+
+func NewServiceAccountCacheMissesCounter() prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "service_account_cache_misses_total",
+		Help:      "Total amount cache misses when looking up ServiceAccount objects.",
+	})
+}
+
+func NewCachedServiceAccountTokensGauge() prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "service_account_tokens",
+		Help:      "Amount of ServiceAccount tokens currently cached.",
+	})
+}
+
+func NewServiceAccountTokenCacheMissesCounter() prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "service_account_token_cache_misses_total",
+		Help:      "Total amount cache misses when fetching ServiceAccount tokens.",
+	})
 }

--- a/internal/pods/watch/provider.go
+++ b/internal/pods/watch/provider.go
@@ -69,17 +69,9 @@ type (
 const ipIndex = "ip"
 
 func NewProvider(opts ProviderOptions) *Provider {
-	numPods := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: metrics.Namespace,
-		Name:      "pods",
-		Help:      "Amount of Pod objects currently cached.",
-	})
+	numPods := metrics.NewCachedPodsGauge()
 	opts.MetricsRegistry.MustRegister(numPods)
-	cacheMisses := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Name:      "pod_cache_misses_total",
-		Help:      "Total amount cache misses when looking up Pod objects.",
-	})
+	cacheMisses := metrics.NewPodCacheMissesCounter()
 	opts.MetricsRegistry.MustRegister(cacheMisses)
 
 	informer := informersv1.NewFilteredPodInformer(

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,203 @@
+// MIT License
+//
+// Copyright (c) 2025 Matheus Pimenta
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"time"
+
+	"github.com/matheuscscp/gke-metadata-server/internal/logging"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+func logger() logrus.FieldLogger {
+	return logging.FromContext(context.Background()).WithField("component", "proxy")
+}
+
+type proxy struct {
+	net.Listener
+
+	queue  chan net.Conn
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	dialLatencyMillis *prometheus.HistogramVec
+	activeConnections prometheus.Gauge
+}
+
+type sniffedConn struct {
+	net.Conn
+	buf []byte
+}
+
+// Listen creates a new proxy listener on the given network and address.
+// It sniffs incoming connections to decide whether to route them to the
+// metadata server or to 169.254.169.254:80. It's supposed to be used with
+// the eBPF routing mode, which allows for proxying connections due to how
+// eBPF can identify the calling process. Supports only the "tcp" network.
+func Listen(address string, dialLatencyMillis *prometheus.HistogramVec,
+	activeConnections prometheus.Gauge) (net.Listener, error) {
+
+	l, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	p := &proxy{
+		Listener: l,
+
+		queue:  make(chan net.Conn, 100),
+		ctx:    ctx,
+		cancel: cancel,
+
+		dialLatencyMillis: dialLatencyMillis,
+		activeConnections: activeConnections,
+	}
+
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				logger().WithError(err).Error("error accepting connection")
+				continue
+			}
+
+			go p.handle(c)
+		}
+	}()
+
+	return p, nil
+}
+
+// Accept implements net.Listener.
+func (p *proxy) Accept() (net.Conn, error) {
+	select {
+	case conn := <-p.queue:
+		return conn, nil
+	case <-p.ctx.Done():
+		return nil, net.ErrClosed
+	}
+}
+
+// Addr implements net.Listener.
+func (p *proxy) Addr() net.Addr {
+	return p.Listener.Addr()
+}
+
+// Close implements net.Listener.
+func (p *proxy) Close() error {
+	p.cancel()
+	return p.Listener.Close()
+}
+
+func (p *proxy) handle(client net.Conn) {
+	// read first line to determine if it's a metadata request
+	var buf []byte
+	matches := true
+	toRead := "GET /computeMetadata/v1"
+	l := logger().WithField("clientAddr", client.RemoteAddr().String())
+	for len(toRead) > 0 {
+		b := make([]byte, len(toRead))
+		n, err := client.Read(b)
+		if err != nil {
+			l.WithError(err).Error("error reading from client")
+			client.Close()
+			return
+		}
+		buf = append(buf, b[:n]...)
+		if string(toRead[:n]) != string(b[:n]) {
+			// not a metadata request
+			matches = false
+			break
+		}
+		toRead = toRead[n:]
+	}
+	client = &sniffedConn{Conn: client, buf: buf}
+
+	// if it's a metadata request, enqueue it and return
+	if matches {
+		select {
+		case p.queue <- client:
+		case <-p.ctx.Done():
+			client.Close()
+		}
+		return
+	}
+
+	// not a metadata request. proxy
+	const serverAddr = "169.254.169.254:80"
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	start := time.Now()
+	server, err := (&net.Dialer{}).DialContext(ctx, "tcp", serverAddr)
+	if err != nil {
+		p.dialLatencyMillis.
+			WithLabelValues(client.RemoteAddr().(*net.TCPAddr).IP.String()).
+			Observe(float64(time.Since(start).Milliseconds()))
+		client.Close()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			l.WithError(err).Errorf("error dialing %s", serverAddr)
+		}
+		return
+	}
+	p.dialLatencyMillis.
+		WithLabelValues(client.RemoteAddr().(*net.TCPAddr).IP.String()).
+		Observe(float64(time.Since(start).Milliseconds()))
+	p.activeConnections.Inc()
+	defer p.activeConnections.Dec()
+	defer client.Close()
+	defer server.Close()
+	done := make(chan struct{}, 2)
+	go func() {
+		io.Copy(server, client)
+		server.(*net.TCPConn).CloseWrite()
+		done <- struct{}{}
+	}()
+	go func() {
+		io.Copy(client, server)
+		client.(*sniffedConn).Conn.(*net.TCPConn).CloseWrite()
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+}
+
+func (s *sniffedConn) Read(b []byte) (int, error) {
+	if len(s.buf) > 0 {
+		n := copy(b, s.buf)
+		s.buf = s.buf[n:]
+		return n, nil
+	}
+	return s.Conn.Read(b)
+}

--- a/internal/server/gke_apis_test.go
+++ b/internal/server/gke_apis_test.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -46,14 +45,6 @@ import (
 	"google.golang.org/api/googleapi"
 	oauth2 "google.golang.org/api/oauth2/v2"
 )
-
-func init() {
-	host := os.Getenv("HOST_IP")
-	port := os.Getenv("GKE_METADATA_SERVER_PORT")
-	if host != "" && port != "" {
-		os.Setenv("GCE_METADATA_HOST", fmt.Sprintf("%s:%s", host, port))
-	}
-}
 
 const (
 	gkeMetadataFlavor = "Google"

--- a/internal/serviceaccounts/watch/provider.go
+++ b/internal/serviceaccounts/watch/provider.go
@@ -63,17 +63,9 @@ type (
 )
 
 func NewProvider(ctx context.Context, opts ProviderOptions) *Provider {
-	numServiceAccounts := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: metrics.Namespace,
-		Name:      "service_accounts",
-		Help:      "Amount of ServiceAccount objects currently cached.",
-	})
+	numServiceAccounts := metrics.NewCachedServiceAccountsGauge()
 	opts.MetricsRegistry.MustRegister(numServiceAccounts)
-	cacheMisses := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Name:      "service_account_cache_misses_total",
-		Help:      "Total amount cache misses when looking up ServiceAccount objects.",
-	})
+	cacheMisses := metrics.NewServiceAccountCacheMissesCounter()
 	opts.MetricsRegistry.MustRegister(cacheMisses)
 
 	informer := informersv1.NewServiceAccountInformer(

--- a/internal/serviceaccounttokens/cache/provider.go
+++ b/internal/serviceaccounttokens/cache/provider.go
@@ -66,17 +66,9 @@ type ProviderOptions struct {
 var errServiceAccountDeleted = errors.New("service account was deleted")
 
 func NewProvider(ctx context.Context, opts ProviderOptions) *Provider {
-	numTokens := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: metrics.Namespace,
-		Name:      "service_account_tokens",
-		Help:      "Amount of ServiceAccount tokens currently cached.",
-	})
+	numTokens := metrics.NewCachedServiceAccountTokensGauge()
 	opts.MetricsRegistry.MustRegister(numTokens)
-	cacheMisses := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Name:      "service_account_token_cache_misses_total",
-		Help:      "Total amount cache misses when fetching ServiceAccount tokens.",
-	})
+	cacheMisses := metrics.NewServiceAccountTokenCacheMissesCounter()
 	opts.MetricsRegistry.MustRegister(cacheMisses)
 
 	// create a new background context for the goroutines with logging from the parent context

--- a/main.go
+++ b/main.go
@@ -89,9 +89,9 @@ func main() {
 
 	flags.StringVar(&stringLogLevel, "log-level", logrus.InfoLevel.String(),
 		"Log level. Accepted values: "+acceptedLogLevels)
-	flags.IntVar(&serverPort, "server-port", 8080,
+	flags.IntVar(&serverPort, "server-port", 16321,
 		"Network address where the metadata server must listen on. Ignored on nodes annotated/labeled with loopback routing")
-	flags.IntVar(&healthPort, "health-port", 8081,
+	flags.IntVar(&healthPort, "health-port", 16322,
 		"Network address where the health server must listen on")
 	flags.StringVar(&projectID, "project-id", "",
 		"Project ID of the GCP project where the GCP Workload Identity Provider is configured")
@@ -297,7 +297,7 @@ func main() {
 		serverAddr = loopback.GKEMetadataServerAddr
 	}
 
-	l.WithFields(map[string]interface{}{
+	l.WithFields(logrus.Fields{
 		"routing":    routingMode,
 		"serverAddr": serverAddr,
 	}).Info("routing mode loaded and attached")
@@ -316,6 +316,7 @@ func main() {
 		ProjectID:            projectID,
 		NumericProjectID:     numericProjectID,
 		WorkloadIdentityPool: workloadIdentityPool,
+		RoutingMode:          routingMode,
 	})
 
 	<-ctx.Done()

--- a/main_test.go
+++ b/main_test.go
@@ -343,7 +343,13 @@ func applyPods(t *testing.T, pods []pod) {
         fieldRef:
           fieldPath: status.hostIP
     - name: GKE_METADATA_SERVER_PORT
-      value: "8080"
+      value: "16321"
+    - name: GCE_METADATA_HOST
+      value: "$(HOST_IP):$(GKE_METADATA_SERVER_PORT)"
+    - name: GCE_METADATA_ROOT
+      value: "$(HOST_IP):$(GKE_METADATA_SERVER_PORT)"
+    - name: GCE_METADATA_IP
+      value: "$(HOST_IP):$(GKE_METADATA_SERVER_PORT)"
 `
 		}
 		var nodeSelector string

--- a/timoni/gke-metadata-server/templates/settings.cue
+++ b/timoni/gke-metadata-server/templates/settings.cue
@@ -39,10 +39,10 @@ import (
 	logLevel?: string & ("panic" | "fatal" | "error" | "warning" | "info" | "debug" | "trace")
 
  	// serverPort is the TCP port for gke-metadata-server to listen HTTP on.
-	serverPort: int & >0 & <65536 | *8080
+	serverPort: int & >0 & <65536 | *16321
 
  	// healthPort is the TCP port for the health server to listen HTTP on.
-	healthPort: int & >0 & <65536 | *8081
+	healthPort: int & >0 & <65536 | *16322
 
 	// watchPods is the watch settings for gke-metadata-server to watch Pods running on the same Node.
 	watchPods: #watchSettings


### PR DESCRIPTION
Fixes: #424 

Also changes the default emulator port from `8080` to `16321` and healthchecks port from `8081` to `16322`. This is to avoid collisions, 8080 is widely used. This change is after I found out that port 8080 is already taken on the host network namespace in EKS Auto Mode, for example.