### PR TITLE
Upgrade gcloud CLI to 564.0.0-slim

### DIFF
--- a/testdata/pod-gcloud.yaml
+++ b/testdata/pod-gcloud.yaml
@@ -14,7 +14,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: gcs
-    image: google/cloud-sdk:563.0.0-slim
+    image: google/cloud-sdk:564.0.0-slim
     command:
     - sh
     - -c


### PR DESCRIPTION
Automated gcloud CLI upgrade to `564.0.0-slim`.

Image: `google/cloud-sdk:564.0.0-slim`

Generated by: https://github.com/matheuscscp/gke-metadata-server/actions/runs/24389411251