### PR TITLE
Upgrade Cilium to v1.19.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 
 TEST_IMAGE := ghcr.io/matheuscscp/gke-metadata-server/test
 PLATFORMS ?= linux/amd64
-CILIUM_VERSION ?= 1.19.2
+CILIUM_VERSION ?= 1.19.3
 
 .PHONY: dev
 dev: tidy gen-ebpf dev-cluster build build-go-test dev-test


### PR DESCRIPTION
Automated Cilium upgrade to `v1.19.3`.

Release: https://github.com/cilium/cilium/releases/tag/v1.19.3

Generated by: https://github.com/matheuscscp/gke-metadata-server/actions/runs/24657462619