### PR TITLE
Kernel-based pod attestation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ terraform.*
 Chart.yaml
 config.cue
 internal/redirect/redirect_bpf*
+internal/attestation/bpf/attest_bpf*
 ebpf/vmlinux.h

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY ./internal/ ./internal/
 COPY ./ebpf/ ./ebpf/
 
 RUN go generate ./internal/redirect
+RUN go generate ./internal/attestation/bpf
 
 # CGO_ENABLED=0 to build a statically-linked binary
 # -ldflags '-w -s' to strip debugging information for smaller size

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -19,6 +19,7 @@ COPY ./internal/ ./internal/
 COPY ./ebpf/ ./ebpf/
 
 RUN go generate ./internal/redirect
+RUN go generate ./internal/attestation/bpf
 
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go test -c github.com/matheuscscp/gke-metadata-server/internal/server

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ gen-timoni:
 .PHONY: gen-ebpf
 gen-ebpf:
 	go generate ./internal/redirect
+	go generate ./internal/attestation/bpf
 
 .PHONY: dev-cluster
 dev-cluster:

--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ In this routing mode the emulator hooks an eBPF program to the `connect()` sysca
 The eBPF program looks at the destination address and, if it matches the hard-coded
 address mentioned above, modifies the address to the actual address of the emulator.
 
+This mode also attaches a `cgroup/sock_ops` program that records the cgroup ID
+of every TCP-connecting task into a 4-tuple-keyed map at `TCP_CONNECT_CB`. The
+emulator consults that map for hostNetwork pod requests and resolves the cgroup
+ID to a pod UID by walking `/sys/fs/cgroup`, giving hostNetwork pods per-pod
+identity (see [Pods running on the host network](#pods-running-on-the-host-network)).
+
 This mode may have conflicts with other eBPF-based tools running in the cluster.
 It works well with a default installation of Cilium, but if you are using Cilium
 to replace `kube-proxy`
@@ -347,52 +353,72 @@ docs [here](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-to
 
 ### Limitations and Security Risks
 
-#### Pod identification by IP address
+#### Pod identification
 
-The emulator uses the client IP address reported in the HTTP request to uniquely identify
-the requesting Pod in the Kubernetes API (just like in the native GKE implementation).
+The strategy is picked per request by `(routing mode, pod kind)`. There is
+no fallback between strategies — each combination has exactly one path.
 
-If an attacker can easily perform IP address impersonation attacks in your cluster, e.g.
-[ARP spoofing](https://cloud.hacktricks.xyz/pentesting-cloud/kubernetes-security/kubernetes-network-attacks),
-then they will most likely exploit this design choice to steal your credentials.
-**Please evaluate the risk of such attacks in your cluster before choosing this tool.**
+| routing mode | non-hostNetwork pod | hostNetwork pod |
+|---|---|---|
+| `eBPF` | kernel attestation (sockops 4-tuple → cgroup ID → pod UID) | same |
+| `Loopback` | source IP → `GetByIP` (node-scoped) | netlink SOCK_DIAG → `/proc/<pid>/cgroup` → pod UID |
+| `None` | source IP → `GetByIP` (node-scoped) | netlink SOCK_DIAG → `/proc/<pid>/cgroup` → pod UID |
 
-*(Please also note that the attack explained in the link above requires Pods configured
-with very high privileges, which should normally not be allowed in sensitive/production
-clusters. If the security of your cluster is really important, then you should be
-[enforcing restrictions](https://github.com/open-policy-agent/gatekeeper) for preventing
-Pods from being created with such high privileges in the majority of cases.)*
+In `eBPF` mode every pod is identified by **kernel attestation** — the
+source IP is not consulted at all. In `Loopback` and `None` modes, regular
+pods are identified by their source IP (pod IPs are unique within a Node
+and `GetByIP` is node-scoped, so this is sound), while hostNetwork pods —
+which share the Node's IP — fall back to the netlink-based attestation
+chain. See the [host-network section](#pods-running-on-the-host-network)
+below for the kernel-attestation details.
+
+The trust root for source IP is the kernel's report on the TCP connection
+— never any HTTP-level header (e.g. `X-Forwarded-For`).
+
+If an attacker can perform source-IP impersonation in your cluster (e.g.
+[ARP spoofing](https://cloud.hacktricks.xyz/pentesting-cloud/kubernetes-security/kubernetes-network-attacks)),
+the source-IP strategy used by `Loopback`/`None` for non-hostNetwork pods
+can be exploited to steal credentials. **Please evaluate the risk of such
+attacks in your cluster before choosing this tool.** The attack referenced
+typically requires Pods running with very high privileges, which should
+normally be blocked in production clusters via PSA, [Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
+or equivalent policy. The kernel-attestation paths (`eBPF` for any pod,
+netlink for hostNetwork pods) do not depend on source IP and are not
+affected by ARP spoofing.
 
 #### Pods running on the host network
 
-In a cluster there may also be Pods running on the *host network*, i.e. Pods with the
-field `spec.hostNetwork` set to `true`. Such Pods share the IP address of the Node
-where they are running on, i.e *their IP is not unique*, and therefore they cannot be
-uniquely identified by the emulator through the client IP address reported in the HTTP
-request (like mentioned in the previous section).
+Pods with `spec.hostNetwork: true` share the Node's IP address, so the
+source IP the emulator sees on the connection is not unique to the pod.
+Both routing-mode-specific kernel-attestation paths are described below;
+the `eBPF` chain is the same path used for *every* pod in `eBPF` mode
+(non-hostNetwork pods are also resolved through it), and the netlink
+chain is only used for hostNetwork pods in `Loopback` and `None` modes.
 
-If your use case requires, Pods running on the host network are allowed to use a
-***shared*** Kubernetes ServiceAccount configured through the following pair of
-annotations or labels on the Node:
+- In `eBPF` routing mode, a `cgroup/sock_ops` BPF program records the
+  connecting task's cgroup ID into a 4-tuple-keyed map at TCP connect time.
+  The emulator looks up the 4-tuple from the accepted connection, walks
+  `/sys/fs/cgroup` to find the matching directory, and extracts the pod UID
+  from the kubelet's `pod<UID>` cgroup naming convention.
+- In `Loopback` and `None` routing modes, the emulator queries the host's
+  socket table via `NETLINK_SOCK_DIAG` to resolve the 4-tuple to its socket
+  inode, walks `/proc/<pid>/fd` to find the owning PID, then reads
+  `/proc/<pid>/cgroup` for the same `pod<UID>` extraction.
 
-```yaml
-node.gke-metadata-server.matheuscscp.io/serviceAccountName: <name>
-node.gke-metadata-server.matheuscscp.io/serviceAccountNamespace: <namespace>
-```
+Both paths produce a kubernetes pod UID without trusting source IP or any
+HTTP-level information. The pod's regular ServiceAccount (configured via
+`spec.serviceAccountName`) is then used; there is **no** node-level shared
+ServiceAccount.
 
-Annotations are preferred over labels because they are less impactful to etcd since
-they are not indexed. Labels are also supported because not all Kubernetes providers
-support configuring annotations on Node pools/groups. KinD, for example, does not
-(see [testdata/kind.yaml](./testdata/kind.yaml)).
+Hard requirements: a Linux kernel with cgroup v2 unified hierarchy and BPF
+cgroup-hook support (in practice any kernel from the last few years —
+`bpf_get_current_cgroup_id` has been available since 4.18). No specific CNI
+is required; Cilium is what the project's kind test setup happens to use,
+not a runtime dependency.
 
-Remember to add appropriate Node selectors/tolerations to your Pods so they are
-scheduled on the Nodes where the shared ServiceAccount is configured. There are
-many different ways to achieve this depending on your use case, so please refer
-to the Kubernetes documentation for more information.
-
-*Be careful when sharing identities between too many workloads! Please assess
-your security requirements and the risks of sharing identities between workloads
-in your cluster.*
+Sandboxed container runtimes (gVisor, Kata) are unsupported because their
+userspace kernels are not visible to host BPF programs and not represented
+in the host's `/proc`.
 
 #### Token Cache
 

--- a/api/api.go
+++ b/api/api.go
@@ -9,9 +9,7 @@ const (
 
 	GroupGKE = "iam.gke.io"
 
-	AnnotationRoutingMode             = GroupNode + "/routingMode"
-	AnnotationServiceAccountName      = GroupNode + "/serviceAccountName"
-	AnnotationServiceAccountNamespace = GroupNode + "/serviceAccountNamespace"
+	AnnotationRoutingMode = GroupNode + "/routingMode"
 
 	RoutingModeDefault  = RoutingModeBPF
 	RoutingModeBPF      = "eBPF"

--- a/ebpf/attest.c
+++ b/ebpf/attest.c
@@ -1,0 +1,114 @@
+// Copyright 2025 Matheus Pimenta.
+// SPDX-License-Identifier: AGPL-3.0
+
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_endian.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+// IPv4 family
+#define AF_INET 2
+
+// Attestation key/value: written by the active-connect sockops hook below
+// and consumed by userspace at HTTP request time. The key is the 4-tuple
+// the kernel will report on the server-side socket (so userspace can match
+// using conn.RemoteAddr() + the daemon's accepted LocalAddr) and the value
+// carries the connecting task's cgroup ID. The cgroup ID is the inode of
+// the cgroup directory in cgroupfs: kernel-attested, namespace-independent,
+// and not reused after the pod cgroup is destroyed.
+struct AttestKey {
+	__u32 src_ip;       // network byte order, matches what server sees
+	__u32 dst_ip;       // ditto
+	__u16 src_port;     // network byte order
+	__u16 dst_port;     // network byte order
+};
+
+struct AttestValue {
+	__u64 cgroup_id;
+};
+
+struct AttestConfig {
+	// reserved for future tuneables; kept as a struct for ABI room.
+	__u64 _reserved;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct AttestConfig);
+} map_attest_config SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 65536);
+	__type(key, struct AttestKey);
+	__type(value, struct AttestValue);
+} map_attest SEC(".maps");
+
+// Debug counters: ran[0] = sockops entered (any op), ran[1] = TCP_CONNECT_CB
+// matched, ran[2] = AF_INET passed, ran[3] = map updated. Lets userspace
+// confirm whether the program is firing and how far it gets.
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 4);
+	__type(key, __u32);
+	__type(value, __u64);
+} map_attest_debug SEC(".maps");
+
+static __always_inline void inc_debug(__u32 idx) {
+	__u64 *c = bpf_map_lookup_elem(&map_attest_debug, &idx);
+	if (c) __sync_fetch_and_add(c, 1);
+}
+
+// Hooks active-side TCP connect to record the connecting task's cgroup ID
+// along with the 4-tuple the kernel will eventually report to the
+// server-side socket.
+//
+// At BPF_SOCK_OPS_TCP_CONNECT_CB the local port has been bound but the SYN
+// has not been sent yet, so the entry is in the map well before the server
+// can possibly accept the connection. Userspace then walks /sys/fs/cgroup
+// to find the directory whose inode equals this cgroup ID and extracts the
+// pod UID from the kubelet's `pod<UID>` cgroup naming convention.
+SEC("sockops")
+int attest_connect(struct bpf_sock_ops *skops) {
+	inc_debug(0);
+	if (skops->op != BPF_SOCK_OPS_TCP_CONNECT_CB) {
+		return 0;
+	}
+	inc_debug(1);
+	if (skops->family != AF_INET) {
+		return 0;
+	}
+	inc_debug(2);
+
+	// local_port is exposed in host byte order in the low 16 bits of a u32.
+	// remote_port is the kernel's __be16 sk_dport shifted into the *high*
+	// 16 bits of the u32 (see net/core/filter.c convert_bpf_sock_ops_access),
+	// so we right-shift before casting to u16. Both ports end up stored in
+	// network byte order so they match userspace's htons-encoded lookup key.
+	struct AttestKey key = {
+		.src_ip = skops->local_ip4,
+		.dst_ip = skops->remote_ip4,
+		.src_port = bpf_htons((__u16)skops->local_port),
+		.dst_port = (__u16)(skops->remote_port >> 16),
+	};
+
+	// We record the connecting task's cgroup ID rather than its pid. The
+	// cgroup ID is the inode of the cgroup directory in cgroupfs and is
+	// global across PID namespaces, so the daemon can resolve it without
+	// any namespace translation, even in nested setups (e.g. kind, where
+	// the daemon's pid namespace is the kind worker's, not the kernel's
+	// root). The pod UID is then derived from the cgroup path.
+	struct AttestValue val = {
+		.cgroup_id = bpf_get_current_cgroup_id(),
+	};
+
+	bpf_map_update_elem(&map_attest, &key, &val, BPF_ANY);
+	inc_debug(3);
+	return 0;
+}
+
+char __LICENSE[] SEC("license") = "GPL";

--- a/ebpf/redirect.c
+++ b/ebpf/redirect.c
@@ -12,7 +12,7 @@
 #define AF_INET 2
 
 struct Config {
-	__u32 emulator_pid;
+	__u64 emulator_cgroup_id;
 	__u32 emulator_ip;
 	__u16 emulator_port;
 	__u16 debug;
@@ -38,11 +38,8 @@ int redirect_connect4(struct bpf_sock_addr *ctx) {
 	const __u32 dst_port = bpf_ntohs(ctx->user_port);
 
 	// 0xA9FEA9FE is 169.254.169.254, the GKE Metadata Server IP address.
-	// 0xA9FEC4F5 is 169.254.196.245, the IP address we chose for
-	// self-discovery of the emulator PID, and 12345 is the port.
-	// If the connection is not targeting either of these addresses,
-	// do nothing, just allow it.
-	if (!(dst == 0xA9FEA9FE && dst_port == 80) && !(dst == 0xA9FEC4F5 && dst_port == 12345)) {
+	// If the connection is not targeting that address on port 80, do nothing.
+	if (dst != 0xA9FEA9FE || dst_port != 80) {
 		return 1;
 	}
 
@@ -55,28 +52,14 @@ int redirect_connect4(struct bpf_sock_addr *ctx) {
 		return 1;
 	}
 
-	// Get the PID of the current process.
-	const __u64 pid_tgid = bpf_get_current_pid_tgid();
-	const __u32 pid = pid_tgid >> 32;
-
-	// If the emulator PID is 0 and the connection is targeting the self-discovery
-	// address, store the current PID as the emulator PID and block the connection.
-	if (conf->emulator_pid == 0) {
-		if (dst == 0xA9FEC4F5 && dst_port == 12345) {
-			conf->emulator_pid = pid;
-			if (conf->debug) {
-				bpf_printk("Discovered emulator PID: %d", pid);
-			}
-			return 0; // Block the connection.
-		}
-		bpf_printk("Error: redirect_connect4 called before emulator PID discovery");
-		return 1;
-	}
-
-	// If the connection is coming from the emulator process, allow it without redirection.
-	if (pid == conf->emulator_pid) {
+	// If the connection is coming from the emulator's cgroup, allow it
+	// without redirection. The cgroup ID is set by userspace at startup
+	// from the inode of the daemon's own cgroup directory; it is
+	// kernel-attested and stable for the lifetime of the daemon's pod.
+	const __u64 cgid = bpf_get_current_cgroup_id();
+	if (cgid == conf->emulator_cgroup_id) {
 		if (conf->debug) {
-			bpf_printk("Not redirecting connection from emulator process (PID: %d)", pid);
+			bpf_printk("Not redirecting connection from emulator cgroup (id: %llu)", cgid);
 		}
 		return 1;
 	}

--- a/helm/gke-metadata-server/templates/daemonset.yaml
+++ b/helm/gke-metadata-server/templates/daemonset.yaml
@@ -20,6 +20,12 @@ spec:
       {{- end }}
     spec:
       hostNetwork: true
+      # hostPID is required by the netlink SOCK_DIAG fallback used in Loopback
+      # and None routing modes for hostNetwork pods: the server walks
+      # /proc/<pid>/fd to map a socket inode back to its owning PID, then
+      # reads /proc/<pid>/cgroup to derive the pod UID. eBPF mode does not
+      # need it (cgroup ID alone identifies the pod).
+      hostPID: true
       serviceAccountName: gke-metadata-server
       priorityClassName: system-node-critical
       affinity:

--- a/helm/gke-metadata-server/templates/daemonset.yaml
+++ b/helm/gke-metadata-server/templates/daemonset.yaml
@@ -120,6 +120,9 @@ spec:
         {{- if .Values.config.podLookup.retryMaxDelay }}
         - --pod-lookup-retry-max-delay={{ .Values.config.podLookup.retryMaxDelay }}
         {{- end }}
+        {{- if .Values.config.testProxyUpstream }}
+        - --test-proxy-upstream
+        {{- end }}
         env:
         - name: NODE_NAME
           valueFrom:

--- a/helm/gke-metadata-server/values.yaml
+++ b/helm/gke-metadata-server/values.yaml
@@ -35,6 +35,11 @@ config:
     maxAttempts: 3 # Maximum number of attempts to try looking up a pod by the client connection IP address.
     retryInitialDelay: 1s # Initial delay for retrying pod lookups upon failures.
     retryMaxDelay: 30s # Maximum delay for retrying pod lookups upon failures.
+  # testProxyUpstream is a TEST-ONLY flag. When true, in eBPF routing mode the
+  # daemon binds 169.254.169.254 to lo and serves a marker on port 80 to allow
+  # the project's e2e suite to assert the proxy-passthrough chain is wired up.
+  # Has no effect outside eBPF mode. Do not enable in production.
+  testProxyUpstream: false
 
 podAnnotations: {}
   # Optionally, configure Prometheus to scrape the server:

--- a/internal/attestation/attestation_test.go
+++ b/internal/attestation/attestation_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Matheus Pimenta.
+// SPDX-License-Identifier: AGPL-3.0
+
+package attestation_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/matheuscscp/gke-metadata-server/internal/attestation"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withFakeProc redirects attestation.ProcRoot to a temporary directory for
+// the duration of the test. Tests populate that directory with /<pid>/cgroup
+// files mirroring the kernel's format.
+func withFakeProc(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old := attestation.ProcRoot
+	attestation.ProcRoot = dir
+	t.Cleanup(func() { attestation.ProcRoot = old })
+	return dir
+}
+
+func writePIDFile(t *testing.T, root string, pid int, name, contents string) {
+	t.Helper()
+	dir := filepath.Join(root, fmt.Sprintf("%d", pid))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o644))
+}
+
+const cgroupV2CgroupfsDriver = `0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod12345678-1234-1234-1234-123456789abc.slice/cri-containerd-deadbeef.scope
+`
+
+const cgroupV2SystemdDriver = `0::/kubepods/besteffort/pod12345678-1234-1234-1234-123456789abc/abcdef
+`
+
+const cgroupV2SystemdUnderscores = `0::/kubepods.slice/kubepods-pod12345678_1234_1234_1234_123456789abc.slice/cri-containerd-deadbeef.scope
+`
+
+const cgroupNonPod = `0::/system.slice/kubelet.service
+`
+
+func TestPodUIDFromCgroup_Cgroupfs(t *testing.T) {
+	root := withFakeProc(t)
+	writePIDFile(t, root, 1, "cgroup", cgroupV2CgroupfsDriver)
+	uid, err := attestation.PodUIDFromCgroup(1)
+	require.NoError(t, err)
+	assert.Equal(t, "12345678-1234-1234-1234-123456789abc", uid)
+}
+
+func TestPodUIDFromCgroup_Systemd(t *testing.T) {
+	root := withFakeProc(t)
+	writePIDFile(t, root, 1, "cgroup", cgroupV2SystemdDriver)
+	uid, err := attestation.PodUIDFromCgroup(1)
+	require.NoError(t, err)
+	assert.Equal(t, "12345678-1234-1234-1234-123456789abc", uid)
+}
+
+func TestPodUIDFromCgroup_SystemdUnderscores(t *testing.T) {
+	// systemd cgroup driver canonicalises hyphens in unit names to
+	// underscores; the parser must normalise back to the API form.
+	root := withFakeProc(t)
+	writePIDFile(t, root, 1, "cgroup", cgroupV2SystemdUnderscores)
+	uid, err := attestation.PodUIDFromCgroup(1)
+	require.NoError(t, err)
+	assert.Equal(t, "12345678-1234-1234-1234-123456789abc", uid)
+}
+
+func TestPodUIDFromCgroup_NotAPod(t *testing.T) {
+	root := withFakeProc(t)
+	writePIDFile(t, root, 1, "cgroup", cgroupNonPod)
+	_, err := attestation.PodUIDFromCgroup(1)
+	require.Error(t, err)
+}
+
+func TestPodUIDFromCgroup_Missing(t *testing.T) {
+	withFakeProc(t)
+	_, err := attestation.PodUIDFromCgroup(42)
+	require.Error(t, err)
+}
+
+func TestPodUIDFromCgroupID(t *testing.T) {
+	root := t.TempDir()
+	old := attestation.CgroupV2Mount
+	attestation.CgroupV2Mount = root
+	t.Cleanup(func() { attestation.CgroupV2Mount = old })
+
+	podDir := filepath.Join(root, "kubepods.slice", "kubepods-besteffort.slice",
+		"kubepods-besteffort-pod12345678-1234-1234-1234-123456789abc.slice")
+	require.NoError(t, os.MkdirAll(podDir, 0o755))
+
+	var st syscall.Stat_t
+	require.NoError(t, syscall.Stat(podDir, &st))
+
+	uid, err := attestation.PodUIDFromCgroupID(st.Ino)
+	require.NoError(t, err)
+	assert.Equal(t, "12345678-1234-1234-1234-123456789abc", uid)
+}
+
+func TestPodUIDFromCgroupID_NotFound(t *testing.T) {
+	root := t.TempDir()
+	old := attestation.CgroupV2Mount
+	attestation.CgroupV2Mount = root
+	t.Cleanup(func() { attestation.CgroupV2Mount = old })
+
+	_, err := attestation.PodUIDFromCgroupID(0xdeadbeef)
+	require.Error(t, err)
+}

--- a/internal/attestation/bpf/bpf.go
+++ b/internal/attestation/bpf/bpf.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Matheus Pimenta.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Package bpf wraps the eBPF sockops program and 4-tuple -> cgroup-ID map
+// that the userspace metadata server consults to derive the kubernetes pod
+// identity of a connecting process. The cgroup ID is resolved to a pod UID
+// by walking /sys/fs/cgroup for the matching inode (see attestation.PodUIDFromCgroupID).
+package bpf
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net/netip"
+	"os"
+
+	"github.com/matheuscscp/gke-metadata-server/internal/attestation"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+)
+
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -type AttestConfig -type AttestKey -type AttestValue attest ../../../ebpf/attest.c
+
+// Map wraps the loaded sockops program and its companion lookup map. Lookup
+// returns ErrNotFound when the 4-tuple is unknown — typically because the
+// connect happened before the program was attached, or the LRU evicted the
+// entry. The (mode, pod-kind) dispatch in the server treats this as a hard
+// attestation failure (HTTP 403); there is no fallback to source IP by
+// design.
+type Map struct {
+	objs attestObjects
+	link link.Link
+}
+
+// ErrNotFound is returned when no record exists for a 4-tuple.
+var ErrNotFound = errors.New("attestation: 4-tuple not in map")
+
+// LoadAndAttach loads the sockops program and attaches it to the host's
+// cgroup root so it fires for every active TCP connect on the node.
+func LoadAndAttach() (*Map, error) {
+	var objs attestObjects
+	if err := loadAttestObjects(&objs, nil); err != nil {
+		return nil, fmt.Errorf("loading attest eBPF objects: %w", err)
+	}
+
+	lnk, err := link.AttachCgroup(link.CgroupOptions{
+		Path:    "/sys/fs/cgroup",
+		Attach:  ebpf.AttachCGroupSockOps,
+		Program: objs.AttestConnect,
+	})
+	if err != nil {
+		objs.Close()
+		return nil, fmt.Errorf("attaching attest sockops program to cgroup: %w", err)
+	}
+
+	return &Map{objs: objs, link: lnk}, nil
+}
+
+// Close detaches the program and frees BPF resources.
+func (m *Map) Close() error {
+	e1 := m.link.Close()
+	e2 := m.objs.Close()
+	return errors.Join(e1, e2)
+}
+
+// Lookup returns the pod UID for the connection identified by the given
+// 4-tuple, derived from the cgroup ID the BPF program recorded at active-
+// connect time. Returns ErrNotFound if the 4-tuple is not in the map.
+func (m *Map) Lookup(srcIP, dstIP netip.Addr, srcPort, dstPort uint16) (string, error) {
+	// The BPF program writes skops->{local,remote}_ip4 (kernel __be32 fields)
+	// directly into the map key, so the in-memory bytes are network byte
+	// order. To match in Go we read the IP bytes as a native-endian uint32
+	// — that preserves the byte ordering verbatim across the boundary.
+	srcIPv4 := srcIP.As4()
+	dstIPv4 := dstIP.As4()
+	key := attestAttestKey{
+		SrcIp:   binary.NativeEndian.Uint32(srcIPv4[:]),
+		DstIp:   binary.NativeEndian.Uint32(dstIPv4[:]),
+		SrcPort: htons(srcPort),
+		DstPort: htons(dstPort),
+	}
+
+	var val attestAttestValue
+	if err := m.objs.attestMaps.MapAttest.Lookup(&key, &val); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) || errors.Is(err, os.ErrNotExist) {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("looking up attestation map: %w", err)
+	}
+	uid, err := attestation.PodUIDFromCgroupID(val.CgroupId)
+	if err != nil {
+		return "", fmt.Errorf("resolving pod from cgroup id %d: %w", val.CgroupId, err)
+	}
+	return uid, nil
+}
+
+func htons(v uint16) uint16 {
+	return v<<8 | v>>8
+}

--- a/internal/attestation/bpf/bpf.go
+++ b/internal/attestation/bpf/bpf.go
@@ -95,6 +95,29 @@ func (m *Map) Lookup(srcIP, dstIP netip.Addr, srcPort, dstPort uint16) (string, 
 	return uid, nil
 }
 
+// Verify checks that the BPF sockops program captured the given 4-tuple.
+// Returns ErrNotFound if the entry isn't there — typically meaning the
+// program is not yet attached or did not fire for this connection. Used by
+// the daemon's readiness probe to gate /readyz on the pipeline being live.
+func (m *Map) Verify(srcIP, dstIP netip.Addr, srcPort, dstPort uint16) error {
+	srcIPv4 := srcIP.As4()
+	dstIPv4 := dstIP.As4()
+	key := attestAttestKey{
+		SrcIp:   binary.NativeEndian.Uint32(srcIPv4[:]),
+		DstIp:   binary.NativeEndian.Uint32(dstIPv4[:]),
+		SrcPort: htons(srcPort),
+		DstPort: htons(dstPort),
+	}
+	var val attestAttestValue
+	if err := m.objs.attestMaps.MapAttest.Lookup(&key, &val); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) || errors.Is(err, os.ErrNotExist) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("verifying attestation map: %w", err)
+	}
+	return nil
+}
+
 func htons(v uint16) uint16 {
 	return v<<8 | v>>8
 }

--- a/internal/attestation/proc.go
+++ b/internal/attestation/proc.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Matheus Pimenta.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Package attestation derives the kubernetes pod identity of a process from
+// kernel-exposed state. The kubelet places every pod's processes under a
+// cgroup whose path contains "pod<UID>", so the pod UID is recoverable
+// either from a PID (read /proc/<pid>/cgroup) or from a cgroup ID (walk
+// /sys/fs/cgroup until the matching inode is found). Both inputs are
+// kernel-attested and cannot be forged from user space.
+//
+// PodUIDFromCgroup is used by the netlink SOCK_DIAG path (Loopback/None
+// routing modes for hostNetwork pods), which resolves a 4-tuple to a PID
+// via the host's socket table and a /proc/*/fd walk.
+//
+// PodUIDFromCgroupID is used by the eBPF sockops path, which records
+// bpf_get_current_cgroup_id() at TCP connect time. Cgroup IDs are
+// namespace-independent, so this works even when the daemon runs inside a
+// nested PID namespace (e.g. inside a kind worker container).
+package attestation
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// ProcRoot is the prefix used to read /proc files. Overridable in tests.
+var ProcRoot = "/proc"
+
+// podUIDPattern matches the "pod<UID>" segment that the kubelet places in
+// every pod cgroup path. Both styles are matched:
+//   - cgroupfs driver: ".../pod<UID>/..."     (UID with hyphens)
+//   - systemd driver:  ".../pod_<UID>.slice"  (UID with underscores)
+//
+// The UID itself is canonicalised to the hyphen form (kubernetes' API form).
+var podUIDPattern = regexp.MustCompile(`pod([0-9a-fA-F]{8}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{12})`)
+
+// PodUIDFromCgroup reads /proc/<pid>/cgroup and extracts the pod UID from
+// the kubepods cgroup path. Only the cgroup v2 unified hierarchy line
+// (hierarchy id "0", empty controllers field) is consulted; hybrid v1+v2
+// systems return the v2 entry, mixed-mode v1 systems are not supported.
+func PodUIDFromCgroup(pid int) (string, error) {
+	f, err := os.Open(fmt.Sprintf("%s/%d/cgroup", ProcRoot, pid))
+	if err != nil {
+		return "", fmt.Errorf("reading /proc/%d/cgroup: %w", pid, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Format: <hierarchy-id>:<controllers>:<path>.
+		fields := strings.SplitN(line, ":", 3)
+		if len(fields) != 3 || fields[0] != "0" || fields[1] != "" {
+			continue
+		}
+		match := podUIDPattern.FindStringSubmatch(fields[2])
+		if match == nil {
+			return "", fmt.Errorf("pid %d cgroup path %q is not under a kubepods pod cgroup", pid, fields[2])
+		}
+		return strings.ReplaceAll(match[1], "_", "-"), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scanning /proc/%d/cgroup: %w", pid, err)
+	}
+	return "", errors.New("no cgroup v2 entry in /proc/" + strconv.Itoa(pid) + "/cgroup")
+}
+
+// CgroupV2Mount is the cgroup v2 unified hierarchy mount point. Overridable
+// in tests.
+var CgroupV2Mount = "/sys/fs/cgroup"
+
+// PodUIDFromCgroupID walks the cgroup v2 hierarchy looking for the directory
+// whose inode equals the given cgroup id (which is what
+// bpf_get_current_cgroup_id() reports), and extracts the pod UID from the
+// matching path. The cgroup ID is namespace-independent and unique to a live
+// pod cgroup, so this resolves the connecting process to its pod without any
+// PID-namespace translation.
+func PodUIDFromCgroupID(cgid uint64) (string, error) {
+	var found string
+	err := filepath.WalkDir(CgroupV2Mount, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Skip permission errors / transient races.
+			if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrPermission) {
+				return nil
+			}
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return nil
+		}
+		if stat.Ino != cgid {
+			return nil
+		}
+		match := podUIDPattern.FindStringSubmatch(path)
+		if match == nil {
+			return fmt.Errorf("cgroup id %d resolved to path %q, which is not under a kubepods pod cgroup", cgid, path)
+		}
+		found = strings.ReplaceAll(match[1], "_", "-")
+		return fs.SkipAll
+	})
+	if err != nil {
+		return "", err
+	}
+	if found == "" {
+		return "", fmt.Errorf("cgroup id %d not found under %s", cgid, CgroupV2Mount)
+	}
+	return found, nil
+}

--- a/internal/attestation/sockdiag/sockdiag.go
+++ b/internal/attestation/sockdiag/sockdiag.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Matheus Pimenta.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Package sockdiag implements kernel-attested pod identification for
+// hostNetwork pods in routing modes that do not use eBPF (Loopback, None).
+//
+// Both endpoints of a hostNetwork pod's TCP connection live in the host
+// network namespace, so the active-side socket is visible to a netlink
+// SOCK_DIAG query on the host. We resolve the connection's 4-tuple to the
+// owning socket's inode, walk /proc/<pid>/fd to find the process that holds
+// an fd backed by that inode, then read /proc/<pid>/cgroup and extract the
+// pod UID from the kubelet's `pod<UID>` cgroup naming convention.
+package sockdiag
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/matheuscscp/gke-metadata-server/internal/attestation"
+
+	"github.com/vishvananda/netlink"
+)
+
+// ErrNotFound mirrors the eBPF map's contract: returned when the connection
+// 4-tuple is not visible in the host's socket table or the inode owner is
+// not in /proc.
+var ErrNotFound = errors.New("sockdiag: 4-tuple not in host socket table")
+
+// Lookuper resolves a connection 4-tuple to the kubernetes pod UID of the
+// owning process via netlink SOCK_DIAG plus a /proc walk.
+type Lookuper struct{}
+
+// New constructs a Lookuper. Stateless; safe to share across goroutines.
+func New() *Lookuper { return &Lookuper{} }
+
+// Lookup implements server.AttestationLookuper.
+func (l *Lookuper) Lookup(srcIP, dstIP netip.Addr, srcPort, dstPort uint16) (string, error) {
+	local := &net.TCPAddr{IP: srcIP.AsSlice(), Port: int(srcPort)}
+	remote := &net.TCPAddr{IP: dstIP.AsSlice(), Port: int(dstPort)}
+
+	sock, err := netlink.SocketGet(local, remote)
+	if err != nil {
+		return "", fmt.Errorf("netlink SocketGet for %s -> %s: %w", local, remote, err)
+	}
+	if sock.INode == 0 {
+		return "", ErrNotFound
+	}
+
+	pid, err := pidForSocketInode(uint64(sock.INode))
+	if err != nil {
+		return "", err
+	}
+
+	uid, err := attestation.PodUIDFromCgroup(pid)
+	if err != nil {
+		return "", fmt.Errorf("resolving pod uid for pid %d: %w", pid, err)
+	}
+	return uid, nil
+}
+
+// pidForSocketInode walks /proc/<pid>/fd looking for a symlink to
+// "socket:[<inode>]". O(processes * fds-per-process) — acceptable for an
+// occasional metadata request handler, but worth caching if the call rate
+// ever grows.
+func pidForSocketInode(inode uint64) (int, error) {
+	target := fmt.Sprintf("socket:[%d]", inode)
+
+	procDir, err := os.Open(attestation.ProcRoot)
+	if err != nil {
+		return 0, fmt.Errorf("opening %s: %w", attestation.ProcRoot, err)
+	}
+	defer procDir.Close()
+
+	for {
+		names, err := procDir.Readdirnames(256)
+		if errors.Is(err, os.ErrClosed) || len(names) == 0 && err != nil {
+			break
+		}
+		for _, name := range names {
+			pid, err := strconv.Atoi(name)
+			if err != nil {
+				continue
+			}
+			fdDir := filepath.Join(attestation.ProcRoot, name, "fd")
+			entries, err := os.ReadDir(fdDir)
+			if err != nil {
+				// Process may have exited between readdir and now;
+				// or we may lack permission for a kernel-thread.
+				continue
+			}
+			for _, e := range entries {
+				link, err := os.Readlink(filepath.Join(fdDir, e.Name()))
+				if err != nil {
+					continue
+				}
+				if link == target {
+					return pid, nil
+				}
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	return 0, fmt.Errorf("%w: no /proc/*/fd link to inode %d", ErrNotFound, inode)
+}

--- a/internal/attestation/sockdiag/sockdiag.go
+++ b/internal/attestation/sockdiag/sockdiag.go
@@ -38,6 +38,13 @@ type Lookuper struct{}
 // New constructs a Lookuper. Stateless; safe to share across goroutines.
 func New() *Lookuper { return &Lookuper{} }
 
+// Verify is a no-op for the netlink path — sockdiag is a stateless query
+// against the host's live socket table, with no asynchronous capture step
+// to gate the daemon's readiness on.
+func (l *Lookuper) Verify(srcIP, dstIP netip.Addr, srcPort, dstPort uint16) error {
+	return nil
+}
+
 // Lookup implements server.AttestationLookuper.
 func (l *Lookuper) Lookup(srcIP, dstIP netip.Addr, srcPort, dstPort uint16) (string, error) {
 	local := &net.TCPAddr{IP: srcIP.AsSlice(), Port: int(srcPort)}

--- a/internal/node/watch/provider.go
+++ b/internal/node/watch/provider.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/matheuscscp/gke-metadata-server/internal/logging"
 	"github.com/matheuscscp/gke-metadata-server/internal/node"
-	"github.com/matheuscscp/gke-metadata-server/internal/serviceaccounts"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +24,6 @@ type (
 		closeChannel  chan struct{}
 		closedChannel chan struct{}
 		informer      cache.SharedIndexInformer
-		listeners     []Listener
 	}
 
 	ProviderOptions struct {
@@ -33,10 +31,6 @@ type (
 		FallbackSource node.Provider
 		KubeClient     *kubernetes.Clientset
 		ResyncPeriod   time.Duration
-	}
-
-	Listener interface {
-		UpdateNodeServiceAccount(*serviceaccounts.Reference)
 	}
 )
 
@@ -50,29 +44,12 @@ func NewProvider(opts ProviderOptions) *Provider {
 		},
 	)
 
-	p := &Provider{
+	return &Provider{
 		opts:          opts,
 		closeChannel:  make(chan struct{}),
 		closedChannel: make(chan struct{}),
 		informer:      informer,
 	}
-
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			saRef := serviceaccounts.ReferenceFromNode(obj.(*corev1.Node))
-			for _, l := range p.listeners {
-				l.UpdateNodeServiceAccount(saRef)
-			}
-		},
-		UpdateFunc: func(oldObj, newObj any) {
-			saRef := serviceaccounts.ReferenceFromNode(newObj.(*corev1.Node))
-			for _, l := range p.listeners {
-				l.UpdateNodeServiceAccount(saRef)
-			}
-		},
-	})
-
-	return p
 }
 
 func (p *Provider) Get(ctx context.Context) (*corev1.Node, error) {
@@ -119,8 +96,4 @@ func (p *Provider) Close() error {
 	close(p.closeChannel)
 	<-p.closedChannel
 	return nil
-}
-
-func (p *Provider) AddListener(l Listener) {
-	p.listeners = append(p.listeners, l)
 }

--- a/internal/pods/list/provider.go
+++ b/internal/pods/list/provider.go
@@ -60,3 +60,22 @@ func (p *Provider) GetByIP(ctx context.Context, ipAddr string) (*corev1.Pod, err
 
 	return &podList.Items[0], nil
 }
+
+func (p *Provider) GetByUID(ctx context.Context, uid string) (*corev1.Pod, error) {
+	fieldSelector := "spec.nodeName=" + p.opts.NodeName
+	podList, err := p.opts.KubeClient.
+		CoreV1().
+		Pods(corev1.NamespaceAll).
+		List(ctx, metav1.ListOptions{FieldSelector: fieldSelector})
+	if err != nil {
+		return nil, fmt.Errorf("error listing pods in the node matching uid %s: %w", uid, err)
+	}
+	podList.Items = pods.FilterPods(podList.Items)
+
+	for i := range podList.Items {
+		if string(podList.Items[i].UID) == uid {
+			return &podList.Items[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no pods found in the node matching uid %s", uid)
+}

--- a/internal/pods/provider.go
+++ b/internal/pods/provider.go
@@ -11,6 +11,11 @@ import (
 
 type Provider interface {
 	GetByIP(ctx context.Context, ipAddr string) (*corev1.Pod, error)
+	// GetByUID looks up a pod by its kubernetes UID. Used for pods identified
+	// through kernel attestation (cgroup → pod UID), where the source IP
+	// alone is not sufficient (notably hostNetwork pods, which share the
+	// node IP).
+	GetByUID(ctx context.Context, uid string) (*corev1.Pod, error)
 }
 
 // FilterPods removes pods that are not running.

--- a/internal/pods/watch/provider.go
+++ b/internal/pods/watch/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -47,7 +48,10 @@ type (
 	}
 )
 
-const ipIndex = "ip"
+const (
+	ipIndex  = "ip"
+	uidIndex = "uid"
+)
 
 func NewProvider(opts ProviderOptions) *Provider {
 	numPods := metrics.NewCachedPodsGauge()
@@ -61,17 +65,27 @@ func NewProvider(opts ProviderOptions) *Provider {
 		opts.ResyncPeriod,
 		cache.Indexers{
 			ipIndex: func(obj any) ([]string, error) {
-				if podIP := obj.(*corev1.Pod).Status.PodIP; podIP != "" {
+				pod := obj.(*corev1.Pod)
+				// hostNetwork pods share the node IP, so indexing them by IP
+				// would make GetByIP return ambiguous results. They are
+				// resolved by UID via kernel attestation instead.
+				if pod.Spec.HostNetwork {
+					return nil, nil
+				}
+				if podIP := pod.Status.PodIP; podIP != "" {
 					return []string{podIP}, nil
+				}
+				return nil, nil
+			},
+			uidIndex: func(obj any) ([]string, error) {
+				if uid := string(obj.(*corev1.Pod).UID); uid != "" {
+					return []string{uid}, nil
 				}
 				return nil, nil
 			},
 		},
 		func(lo *metav1.ListOptions) {
-			lo.FieldSelector = strings.Join([]string{
-				"spec.nodeName=" + opts.NodeName,
-				"spec.hostNetwork=false",
-			}, ",")
+			lo.FieldSelector = "spec.nodeName=" + opts.NodeName
 		},
 	)
 
@@ -125,6 +139,54 @@ func (p *Provider) GetByIP(ctx context.Context, ipAddr string) (*corev1.Pod, err
 	}
 	p.cacheMisses.Inc()
 	return pod, nil
+}
+
+func (p *Provider) GetByUID(ctx context.Context, uid string) (*corev1.Pod, error) {
+	pod, err := p.getByUID(uid)
+	if err == nil {
+		return pod, nil
+	}
+	if p.opts.FallbackSource == nil {
+		return nil, fmt.Errorf("error getting pod with uid %s from cache: %w", uid, err)
+	}
+
+	logging.
+		FromContext(ctx).
+		WithError(err).
+		WithField("pod_uid", uid).
+		Error("error getting pod by uid from cache, delegating request to fallback source")
+
+	pod, err = p.opts.FallbackSource.GetByUID(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	p.cacheMisses.Inc()
+	return pod, nil
+}
+
+func (p *Provider) getByUID(uid string) (*corev1.Pod, error) {
+	list, err := p.informer.GetIndexer().Index(uidIndex, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID(uid)},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cache: error listing pods in the node matching uid %s: %w", uid, err)
+	}
+	list = pods.FilterPods(list)
+
+	if n := len(list); n != 1 {
+		if n == 0 {
+			return nil, fmt.Errorf("cache: no pods found in the node matching uid %s", uid)
+		}
+		refs := make([]string, n)
+		for i, v := range list {
+			pod := v.(*corev1.Pod)
+			refs[i] = fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+		}
+		return nil, fmt.Errorf("cache: multiple pods found in the node matching uid %s (%v pods): %s",
+			uid, n, strings.Join(refs, ", "))
+	}
+
+	return list[0].(*corev1.Pod), nil
 }
 
 func (p *Provider) getByIP(ipAddr string) (*corev1.Pod, error) {

--- a/internal/proxytest/upstream.go
+++ b/internal/proxytest/upstream.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Matheus Pimenta.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Package proxytest contains a test-only HTTP marker server bound to
+// 169.254.169.254:80 inside the daemon's host network namespace. It exists
+// purely to e2e-test the eBPF-mode proxy passthrough chain:
+//
+//	app pod connects 169.254.169.254:80 (non-metadata path)
+//	  → cgroup/connect4 rewrites destination to the daemon's listen addr
+//	  → proxy.handle() sniffs the request, recognises non-metadata
+//	  → daemon dials 169.254.169.254:80
+//	  → cgroup/connect4 sees the daemon's cgroup, exempts the connect
+//	  → connection routes via lo to this server
+//	  → marker is returned and proxied back to the app pod
+//
+// A successful end-to-end response from the marker server thus proves that
+// the redirect's self-exemption (the kernel-level half) and the userspace
+// sniff/forward (the userspace half) are both wired up correctly.
+package proxytest
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	// HeaderName is the response header carrying the marker.
+	HeaderName = "X-Proxy-Test-Marker"
+	// Marker is the value asserted by the e2e test.
+	Marker = "gke-metadata-server-proxy-passthrough-ok"
+	// Path is the URL path the test pod requests. Anything not starting with
+	// "/computeMetadata/v1" causes proxy.handle() to take the forward branch.
+	Path = "/_proxy_test"
+
+	listenAddr = "169.254.169.254:80"
+	addrCIDR   = "169.254.169.254/32"
+)
+
+// Start binds 169.254.169.254 to the loopback interface and serves the
+// marker on port 80. It returns once the listener is up so callers can use
+// /readyz to gate readiness on the full chain being live. The HTTP server
+// runs in a background goroutine and is left running for the daemon's
+// lifetime; the test cluster is torn down between runs so we don't bother
+// with a teardown path.
+func Start() error {
+	lo, err := netlink.LinkByName("lo")
+	if err != nil {
+		return fmt.Errorf("looking up lo: %w", err)
+	}
+	a, err := netlink.ParseAddr(addrCIDR)
+	if err != nil {
+		return fmt.Errorf("parsing addr: %w", err)
+	}
+	a.Scope = int(netlink.SCOPE_HOST)
+	if err := netlink.AddrAdd(lo, a); err != nil && !errors.Is(err, syscall.EEXIST) {
+		return fmt.Errorf("adding %s to lo: %w", addrCIDR, err)
+	}
+
+	lis, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return fmt.Errorf("listening on %s: %w", listenAddr, err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(HeaderName, Marker)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	go http.Serve(lis, mux)
+	return nil
+}

--- a/internal/redirect/redirect.go
+++ b/internal/redirect/redirect.go
@@ -4,11 +4,15 @@
 package redirect
 
 import (
+	"bufio"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"net"
 	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
 
 	"github.com/matheuscscp/gke-metadata-server/internal/logging"
 
@@ -19,6 +23,8 @@ import (
 //go:generate sh -c "bpftool btf dump file /sys/kernel/btf/vmlinux format c > ../../ebpf/vmlinux.h"
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -type Config redirect ../../ebpf/redirect.c
 
+const cgroupv2Mount = "/sys/fs/cgroup"
+
 func LoadAndAttach(emulatorIP netip.Addr, emulatorPort int) func() (func() error, error) {
 	return func() (func() error, error) {
 		var objs redirectObjects
@@ -26,12 +32,20 @@ func LoadAndAttach(emulatorIP netip.Addr, emulatorPort int) func() (func() error
 			return nil, fmt.Errorf("error loading redirect eBPF redirect objects: %w", err)
 		}
 
+		// Resolve the daemon's own cgroup ID so the eBPF program can identify
+		// outbound connections from the emulator itself (e.g. proxy passthrough
+		// to the real metadata server) and let them through unredirected.
+		cgroupID, err := selfCgroupID()
+		if err != nil {
+			return nil, fmt.Errorf("error resolving emulator cgroup id: %w", err)
+		}
+
 		// Configure the eBPF program with the emulator's IP and port.
 		emulatorIPv4 := emulatorIP.As4()
 		config := redirectConfig{
-			EmulatorPid:  0, // Will be discovered later.
-			EmulatorIp:   binary.BigEndian.Uint32(emulatorIPv4[:]),
-			EmulatorPort: uint16(emulatorPort),
+			EmulatorCgroupId: cgroupID,
+			EmulatorIp:       binary.BigEndian.Uint32(emulatorIPv4[:]),
+			EmulatorPort:     uint16(emulatorPort),
 		}
 		if logging.Debug() {
 			config.Debug = 1
@@ -43,19 +57,12 @@ func LoadAndAttach(emulatorIP netip.Addr, emulatorPort int) func() (func() error
 
 		// Attach the eBPF program to the cgroup.
 		link, err := link.AttachCgroup(link.CgroupOptions{
-			Path:    "/sys/fs/cgroup",
+			Path:    cgroupv2Mount,
 			Attach:  ebpf.AttachCGroupInet4Connect,
 			Program: objs.RedirectConnect4,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("error attaching redirect eBPF program to cgroup: %w", err)
-		}
-
-		// Create a connection to the discovery endpoint to trigger PID discovery.
-		discoveryConn, err := net.Dial("tcp", "169.254.196.245:12345")
-		if err == nil {
-			discoveryConn.Close()
-			return nil, errors.New("pid discovery connection was supposed to return an error")
 		}
 
 		return func() (err error) {
@@ -70,4 +77,45 @@ func LoadAndAttach(emulatorIP netip.Addr, emulatorPort int) func() (func() error
 			return errors.Join(e1, e2)
 		}, nil
 	}
+}
+
+// selfCgroupID resolves the kernel cgroup ID of the daemon's own cgroup. The
+// cgroup ID is the inode number of the cgroup directory in cgroupfs and is
+// what bpf_get_current_cgroup_id() returns from inside an eBPF program.
+//
+// Only cgroup v2 (unified hierarchy) is supported. The caller's cgroup is
+// read from /proc/self/cgroup, which on a unified system has a single line
+// of the form "0::<path>".
+func selfCgroupID() (uint64, error) {
+	f, err := os.Open("/proc/self/cgroup")
+	if err != nil {
+		return 0, fmt.Errorf("error opening /proc/self/cgroup: %w", err)
+	}
+	defer f.Close()
+
+	var cgroupPath string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Format: <hierarchy-id>:<controllers>:<path>. The unified-v2 line
+		// has hierarchy-id "0" and empty controllers.
+		fields := strings.SplitN(line, ":", 3)
+		if len(fields) == 3 && fields[0] == "0" && fields[1] == "" {
+			cgroupPath = fields[2]
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("error reading /proc/self/cgroup: %w", err)
+	}
+	if cgroupPath == "" {
+		return 0, errors.New("could not find cgroup v2 entry in /proc/self/cgroup; only the unified hierarchy is supported")
+	}
+
+	dir := filepath.Join(cgroupv2Mount, cgroupPath)
+	var st syscall.Stat_t
+	if err := syscall.Stat(dir, &st); err != nil {
+		return 0, fmt.Errorf("error stating cgroup directory %q: %w", dir, err)
+	}
+	return st.Ino, nil
 }

--- a/internal/server/gke_apis_test.go
+++ b/internal/server/gke_apis_test.go
@@ -37,6 +37,22 @@ var gkeHeaders = http.Header{
 	"Metadata-Flavor": []string{gkeMetadataFlavor},
 }
 
+// isDirectAccessPod reports whether this test container is running as one of
+// the pods bound to the un-impersonated `test` ServiceAccount. Those pods
+// share an IAM binding for direct GCS access but do NOT have a GSA annotation,
+// so the Identity API and scoped-token tests must take the negative branch.
+//
+// We read POD_NAME (set via the downward API) rather than HOSTNAME because
+// hostNetwork pods share the host's UTS namespace — their HOSTNAME is the
+// node name, not the pod name.
+func isDirectAccessPod() bool {
+	switch os.Getenv("POD_NAME") {
+	case "test-direct-access", "test-host-network-ebpf-disambig":
+		return true
+	}
+	return false
+}
+
 func TestOnGCE(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -173,7 +189,7 @@ func TestGKEServiceAccountTokenAPI_DefaultTokenSource(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, token.AccessToken)
 
-	if os.Getenv("HOSTNAME") != "test-direct-access" {
+	if !isDirectAccessPod() {
 		svc, err := oauth2.NewService(ctx)
 		require.NoError(t, err)
 
@@ -195,7 +211,7 @@ func TestGKEServiceAccountIdentityAPI(t *testing.T) {
 	const expectedSubject = `^\d{20,30}$`
 	const url = "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity?audience=" + expectedAudience
 
-	if os.Getenv("HOSTNAME") == "test-direct-access" {
+	if isDirectAccessPod() {
 		const expectedMsg = `Your Kubernetes service account (default/test) is not annotated with a target Google service account, which is a requirement for retrieving Identity Tokens using Workload Identity.
 Please add the iam.gke.io/gcp-service-account=[GSA_NAME]@[PROJECT_ID] annotation to your Kubernetes service account.
 Refer to https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity

--- a/internal/server/gke_apis_test.go
+++ b/internal/server/gke_apis_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
+	"github.com/matheuscscp/gke-metadata-server/internal/proxytest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2/google"
@@ -197,6 +198,40 @@ func TestGKEServiceAccountTokenAPI_DefaultTokenSource(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, scope, tokenInfo.Scope)
 	}
+}
+
+// TestProxyPassthrough proves the eBPF-mode proxy passthrough end-to-end:
+// the test pod GETs a non-metadata path on 169.254.169.254. cgroup/connect4
+// rewrites the destination to the daemon's listener; proxy.handle() sniffs
+// the prefix, sees it isn't /computeMetadata/v1, and dials 169.254.169.254:80
+// itself; cgroup/connect4 sees the daemon's cgroup and exempts the connect,
+// so the dial reaches the in-daemon test marker server (bound to lo by
+// --test-proxy-upstream). Receiving the marker proves both halves of the
+// chain work — the redirect's self-exemption (kernel) and the userspace
+// sniff/forward (Go).
+//
+// Skipped on pods that aren't pinned to eBPF nodes (where the marker server
+// isn't reachable); main_test.go sets EXPECT_PROXY_UPSTREAM=true on the
+// eBPF-pinned pods to gate this.
+func TestProxyPassthrough(t *testing.T) {
+	if os.Getenv("EXPECT_PROXY_UPSTREAM") != "true" {
+		t.Skip("EXPECT_PROXY_UPSTREAM not set — pod is not on an eBPF node")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	url := "http://169.254.169.254" + proxytest.Path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+	// Force a fresh TCP connection. The proxy sniff happens once at the
+	// start of each connection; reusing a kept-alive connection from an
+	// earlier metadata request would route this non-metadata request to
+	// the inner listener instead of the upstream.
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, proxytest.Marker, resp.Header.Get(proxytest.HeaderName))
 }
 
 func TestGKEServiceAccountIdentityAPI(t *testing.T) {

--- a/internal/server/pods.go
+++ b/internal/server/pods.go
@@ -5,13 +5,16 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/netip"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/matheuscscp/gke-metadata-server/api"
 	pkghttp "github.com/matheuscscp/gke-metadata-server/internal/http"
 	"github.com/matheuscscp/gke-metadata-server/internal/logging"
 	"github.com/matheuscscp/gke-metadata-server/internal/retry"
@@ -135,7 +138,7 @@ func (s *Server) getPodServiceAccountReference(w http.ResponseWriter,
 	// datagrams/TCP segments the network interface delivered to the
 	// server. if this gets compromised, game over. this is the core
 	// security assumption of the project.
-	clientHost, _, err := net.SplitHostPort(r.RemoteAddr)
+	clientHost, clientPortStr, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		const format = "error spliting host-port for %q: %w"
 		pkghttp.RespondErrorf(w, r, http.StatusInternalServerError, format, r.RemoteAddr, err)
@@ -151,71 +154,116 @@ func (s *Server) getPodServiceAccountReference(w http.ResponseWriter,
 	l := logging.FromRequest(r).WithField("client_ip", clientIP)
 	r = logging.IntoRequest(r, l)
 
-	// fetch pod by ip
-	pod, err := s.lookupPodByIP(r.Context(), clientIP)
-	if err != nil {
-		if strings.Contains(err.Error(), "no pods found") {
-			return s.getNodeServiceAccountReference(w, r, clientIP)
+	// Pick the resolution strategy by (routing mode, pod kind). Each
+	// (mode, kind) has exactly one strategy — no fallback between paths.
+	//
+	//   eBPF mode:     kernel attestation for both pod kinds (sockops map).
+	//   Loopback/None: source IP for non-hostNetwork; sockdiag for
+	//                  hostNetwork (the only way to disambiguate pods that
+	//                  share the node IP without an eBPF map).
+	//
+	// hostNetwork pods on Loopback/None modes don't have a single canonical
+	// source IP — the kernel picks one based on the route used to reach the
+	// listener (the link-local 169.254.169.254 for Loopback's lo bind, the
+	// node IP for None's wildcard bind, possibly 127.0.0.1 if the operator
+	// set GCE_METADATA_HOST that way). Anything that isn't a regular
+	// routable pod IP is treated as a host-source connection.
+	useAttestation := s.opts.RoutingMode == api.RoutingModeBPF || isHostSourceIP(clientIPAddr, s.opts.PodIP)
+
+	var pod *corev1.Pod
+	if useAttestation {
+		pod, err = s.attestByConnTuple(r, clientIPAddr, clientPortStr)
+		if err != nil {
+			pkghttp.RespondErrorf(w, r, http.StatusForbidden, "kernel attestation failed: %w", err)
+			return nil, nil, fmt.Errorf("kernel attestation failed: %w", err)
 		}
-		const format = "error looking up pod by ip address: %w"
-		pkghttp.RespondErrorf(w, r, retry.HTTPStatusCode(err), format, err)
-		return nil, nil, fmt.Errorf(format, err)
+	} else {
+		pod, err = s.lookupPodByIP(r.Context(), clientIP)
+		if err != nil {
+			const format = "error looking up pod by ip address: %w"
+			pkghttp.RespondErrorf(w, r, retry.HTTPStatusCode(err), format, err)
+			return nil, nil, fmt.Errorf(format, err)
+		}
 	}
 
-	// update context, logger and request
+	return s.assignPodServiceAccount(r, pod)
+}
+
+// assignPodServiceAccount stores the resolved pod's ServiceAccount reference
+// on the request context and enriches the logger. Shared between the
+// attestation and source-IP resolution paths.
+func (s *Server) assignPodServiceAccount(r *http.Request, pod *corev1.Pod) (*serviceaccounts.Reference, *http.Request, error) {
 	saRef := serviceaccounts.ReferenceFromPod(pod)
 	ctx := context.WithValue(r.Context(), podServiceAccountReferenceContextKey{}, saRef)
-	l = l.WithField("pod", logrus.Fields{
+	l := logging.FromRequest(r).WithField("pod", logrus.Fields{
 		"name":                 pod.Name,
 		"namespace":            pod.Namespace,
 		"service_account_name": pod.Spec.ServiceAccountName,
 	})
 	r = logging.IntoRequest(r.WithContext(ctx), l)
-
 	return saRef, r, nil
 }
 
-// getNodeServiceAccountReference retrieves the reference of the ServiceAccount that should
-// be used by the Node, but only if the client IP address is the same as the Node's IP address.
-// If there's an error this function sends the response to the client.
-func (s *Server) getNodeServiceAccountReference(w http.ResponseWriter,
-	r *http.Request, clientIP string) (*serviceaccounts.Reference, *http.Request, error) {
+// isHostSourceIP reports whether clientIP looks like a connection from the
+// host's network namespace rather than from a pod-network IP. hostNetwork
+// pods share their node's network stack, so the kernel-chosen source IP for
+// their connections to the daemon is whatever the route picks: the node IP
+// (when the listener is on a node-IP-reachable address), the lo-bound
+// link-local 169.254.169.254 (Loopback mode), or 127.0.0.1 (when an operator
+// points GCE_METADATA_HOST at loopback). None of these are pod-network IPs,
+// so this distinguishes hostNetwork from non-hostNetwork callers reliably
+// enough for routing-mode dispatch.
+func isHostSourceIP(clientIP netip.Addr, podIP string) bool {
+	if clientIP.IsLoopback() || clientIP.IsLinkLocalUnicast() {
+		return true
+	}
+	if pip, err := netip.ParseAddr(podIP); err == nil && clientIP == pip {
+		return true
+	}
+	return false
+}
 
-	// check if client ip matches the current node's ip
-	if clientIP != s.opts.PodIP {
-		const format = "client ip address does not match any pods running on the node %s: %s"
-		pkghttp.RespondErrorf(w, r, http.StatusForbidden, format, s.opts.NodeName, clientIP)
-		return nil, nil, fmt.Errorf(format, s.opts.NodeName, clientIP)
+// attestByConnTuple resolves the connecting process to its pod via the
+// configured kernel-attestation lookuper (BPF sockops map in eBPF mode,
+// netlink SOCK_DIAG + /proc walk in Loopback/None) and a UID-based pod
+// lookup. Any failure is returned to the caller; there is no fallback by
+// design — each (routing mode, pod kind) has exactly one resolution
+// strategy.
+func (s *Server) attestByConnTuple(r *http.Request, clientIP netip.Addr, clientPortStr string) (*corev1.Pod, error) {
+	if s.opts.Attestation == nil {
+		return nil, errors.New("attestation lookuper not configured for this routing mode")
 	}
 
-	// get current node
-	node, err := s.getCurrentNode(r.Context())
+	clientPort, err := strconv.ParseUint(clientPortStr, 10, 16)
 	if err != nil {
-		const format = "error getting current node: %w"
-		pkghttp.RespondErrorf(w, r, retry.HTTPStatusCode(err), format, err)
-		return nil, nil, fmt.Errorf(format, err)
+		return nil, fmt.Errorf("parsing client port %q: %w", clientPortStr, err)
 	}
 
-	// get node service account reference
-	saRef := serviceaccounts.ReferenceFromNode(node)
-	if saRef == nil {
-		const format = "node does not have the service account annotations/labels: %s"
-		pkghttp.RespondErrorf(w, r, http.StatusForbidden, format, s.opts.NodeName)
-		return nil, nil, fmt.Errorf(format, s.opts.NodeName)
+	// Use the kernel-chosen LocalAddr of this connection as the destination
+	// of the 4-tuple lookup. This is what the kernel saw when it accepted
+	// the connection, so it matches what sockops recorded (eBPF mode) and
+	// what netlink SOCK_DIAG sees in the live socket table (Loopback/None).
+	// PodIP plus a configured port wouldn't work on Loopback mode where the
+	// listener is on 169.254.169.254:80, not on PodIP.
+	local := LocalAddrFromRequest(r)
+	if local == nil {
+		return nil, errors.New("local addr not captured for this connection")
+	}
+	dstIP, ok := netip.AddrFromSlice(local.IP.To4())
+	if !ok {
+		return nil, fmt.Errorf("local addr %v is not an IPv4 address", local.IP)
 	}
 
-	// update context, logger and request
-	ctx := context.WithValue(r.Context(), podServiceAccountReferenceContextKey{}, saRef)
-	l := logging.FromRequest(r).WithField("node", logrus.Fields{
-		"name": s.opts.NodeName,
-		"service_account": logrus.Fields{
-			"name":      saRef.Name,
-			"namespace": saRef.Namespace,
-		},
-	})
-	r = logging.IntoRequest(r.WithContext(ctx), l)
+	uid, err := s.opts.Attestation.Lookup(clientIP, dstIP.Unmap(), uint16(clientPort), uint16(local.Port))
+	if err != nil {
+		return nil, fmt.Errorf("attestation lookup: %w", err)
+	}
 
-	return saRef, r, nil
+	pod, err := s.opts.Pods.GetByUID(r.Context(), uid)
+	if err != nil {
+		return nil, fmt.Errorf("getting pod with uid %s: %w", uid, err)
+	}
+	return pod, nil
 }
 
 func (s *Server) lookupPodByIP(ctx context.Context, clientIP string) (*corev1.Pod, error) {
@@ -242,22 +290,4 @@ func (s *Server) lookupPodByIP(ctx context.Context, clientIP string) (*corev1.Po
 	})
 
 	return pod, err
-}
-
-func (s *Server) getCurrentNode(ctx context.Context) (*corev1.Node, error) {
-	getNodeFailures := s.metrics.getNodeFailures
-
-	var node *corev1.Node
-	err := retry.Do(ctx, retry.Operation{
-		Description:    "get the current node",
-		FailureCounter: getNodeFailures,
-		Func: func() error {
-			var err error
-			node, err = s.opts.Node.Get(ctx)
-			return err
-		},
-		IsRetryable: func(error) bool { return true },
-	})
-
-	return node, err
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,13 +10,13 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/netip"
 	"time"
 
 	"github.com/matheuscscp/gke-metadata-server/api"
 	pkghttp "github.com/matheuscscp/gke-metadata-server/internal/http"
 	"github.com/matheuscscp/gke-metadata-server/internal/logging"
 	"github.com/matheuscscp/gke-metadata-server/internal/metrics"
-	"github.com/matheuscscp/gke-metadata-server/internal/node"
 	"github.com/matheuscscp/gke-metadata-server/internal/pods"
 	"github.com/matheuscscp/gke-metadata-server/internal/proxy"
 	"github.com/matheuscscp/gke-metadata-server/internal/serviceaccounts"
@@ -25,6 +25,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
+
+// localAddrContextKey is the context key under which the metadataServer's
+// ConnContext stashes the accepted socket's LocalAddr.
+type localAddrContextKey struct{}
+
+// LocalAddrFromRequest returns the server-side LocalAddr of the connection
+// the request arrived on, or nil if it was not captured.
+func LocalAddrFromRequest(r *http.Request) *net.TCPAddr {
+	v, _ := r.Context().Value(localAddrContextKey{}).(*net.TCPAddr)
+	return v
+}
 
 type (
 	Server struct {
@@ -40,7 +51,6 @@ type (
 		Addr                 string
 		HealthPort           int
 		Pods                 pods.Provider
-		Node                 node.Provider
 		ServiceAccounts      serviceaccounts.Provider
 		ServiceAccountTokens serviceaccounttokens.Provider
 		MetricsRegistry      *prometheus.Registry
@@ -49,6 +59,21 @@ type (
 		WorkloadIdentityPool string
 		RoutingMode          string
 		PodLookup            PodLookupOptions
+
+		// Attestation resolves a connection 4-tuple to the kubernetes pod
+		// UID of the connecting process. Required in eBPF mode and for
+		// hostNetwork pods in Loopback or None modes; the (mode, pod-kind)
+		// selection in pods.go decides whether it is consulted for a given
+		// request.
+		Attestation AttestationLookuper
+	}
+
+	// AttestationLookuper resolves a connection 4-tuple to the kubernetes
+	// pod UID of the connecting process. Implementations differ by routing
+	// mode (eBPF sockops map vs netlink SOCK_DIAG + /proc walk) but both
+	// converge on a kernel-attested pod identity.
+	AttestationLookuper interface {
+		Lookup(srcIP, dstIP netip.Addr, srcPort, dstPort uint16) (podUID string, err error)
 	}
 
 	PodLookupOptions struct {
@@ -59,7 +84,6 @@ type (
 
 	serverMetrics struct {
 		lookupPodFailures *prometheus.CounterVec
-		getNodeFailures   prometheus.Counter
 	}
 )
 
@@ -98,9 +122,6 @@ func New(ctx context.Context, opts ServerOptions) *Server {
 	lookupPodFailures := metrics.NewLookupPodFailuresCounter()
 	opts.MetricsRegistry.MustRegister(lookupPodFailures)
 
-	getNodeFailures := metrics.NewGetNodeFailuresCounter()
-	opts.MetricsRegistry.MustRegister(getNodeFailures)
-
 	proxyDialLatencyMillis := metrics.NewProxyDialLantencyMillis()
 	opts.MetricsRegistry.MustRegister(proxyDialLatencyMillis)
 
@@ -128,12 +149,24 @@ func New(ctx context.Context, opts ServerOptions) *Server {
 		opts: opts,
 		metrics: serverMetrics{
 			lookupPodFailures: lookupPodFailures,
-			getNodeFailures:   getNodeFailures,
 		},
 		metadataServer: &http.Server{
 			Addr:        opts.Addr,
 			BaseContext: baseContext,
-			Handler:     observabilityMiddleware(metadataHandler),
+			// ConnContext stashes the accepted socket's LocalAddr in the
+			// request context so the request handler can use it as the
+			// destination for kernel-attestation 4-tuple lookups. The
+			// listener bind address (e.g. ":16321" wildcard) is not
+			// equivalent to the actual local addr the kernel chose for
+			// each connection, especially on Loopback mode where the
+			// link-local 169.254.169.254 differs from PodIP.
+			ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+				if a, ok := c.LocalAddr().(*net.TCPAddr); ok {
+					ctx = context.WithValue(ctx, localAddrContextKey{}, a)
+				}
+				return ctx
+			},
+			Handler: observabilityMiddleware(metadataHandler),
 		},
 		healthServer: &http.Server{
 			Addr:        healthAddr,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,6 +74,12 @@ type (
 	// converge on a kernel-attested pod identity.
 	AttestationLookuper interface {
 		Lookup(srcIP, dstIP netip.Addr, srcPort, dstPort uint16) (podUID string, err error)
+		// Verify checks that the attestation pipeline correctly captured the
+		// connection identified by the given 4-tuple. Used by the readiness
+		// probe to gate /readyz on attestation being live; in eBPF mode this
+		// confirms the sockops program actually fired and recorded the entry,
+		// in netlink modes it's a no-op.
+		Verify(srcIP, dstIP netip.Addr, srcPort, dstPort uint16) error
 	}
 
 	PodLookupOptions struct {
@@ -193,41 +199,65 @@ func New(ctx context.Context, opts ServerOptions) *Server {
 	healthHandler.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+	// /readyz exercises the full request path against the daemon itself
+	// using a fresh TCP connection (DisableKeepAlives), then asks the
+	// attestation lookuper whether it captured that connection's 4-tuple.
+	// In eBPF mode this gates readiness on the sockops program actually
+	// firing for new connects; in netlink modes the verify is a no-op.
 	healthHandler.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		l := logging.FromRequest(r)
+		var local, remote *net.TCPAddr
+		client := &http.Client{Transport: &http.Transport{
+			DisableKeepAlives: true,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+				if err == nil {
+					local = conn.LocalAddr().(*net.TCPAddr)
+					remote = conn.RemoteAddr().(*net.TCPAddr)
+				}
+				return conn, err
+			},
+		}}
 		url := fmt.Sprintf("http://%s%s", opts.Addr, gkeNodeNameAPI)
 		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
 		if err != nil {
-			logging.FromRequest(r).WithError(err).Error("error creating healthcheck request")
+			l.WithError(err).Error("readiness: building self request")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		req.Header.Set(pkghttp.MetadataFlavorHeader, pkghttp.MetadataFlavorGoogle)
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := client.Do(req)
 		if err != nil {
-			logging.FromRequest(r).WithError(err).Error("error performing healthcheck request")
+			l.WithError(err).Error("readiness: self request failed")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			logging.FromRequest(r).WithField("status_code", resp.StatusCode).Error("healthcheck request failed")
+			l.WithField("status_code", resp.StatusCode).Error("readiness: self request returned non-200")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		b, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			logging.FromRequest(r).WithError(err).Error("error reading healthcheck response")
+			l.WithError(err).Error("readiness: reading self response")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		if string(b) != opts.NodeName {
-			l := logging.FromRequest(r).WithFields(logrus.Fields{
-				"node_name": opts.NodeName,
-				"response":  string(b),
-			})
-			l.Error("healthcheck failed, response does not match expected node name")
+		if string(body) != opts.NodeName {
+			l.WithFields(logrus.Fields{"node_name": opts.NodeName, "response": string(body)}).
+				Error("readiness: self response does not match expected node name")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
+		}
+		if opts.Attestation != nil && local != nil && remote != nil {
+			src, _ := netip.AddrFromSlice(local.IP.To4())
+			dst, _ := netip.AddrFromSlice(remote.IP.To4())
+			if err := opts.Attestation.Verify(src.Unmap(), dst.Unmap(), uint16(local.Port), uint16(remote.Port)); err != nil {
+				l.WithError(err).Error("readiness: attestation pipeline did not capture self-connection")
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 		}
 		w.WriteHeader(http.StatusOK)
 	})

--- a/internal/serviceaccounts/helpers.go
+++ b/internal/serviceaccounts/helpers.go
@@ -41,29 +41,6 @@ func ReferenceFromPod(pod *corev1.Pod) *Reference {
 	}
 }
 
-// ReferenceFromNode returns a ServiceAccount reference from the Node object annotations or labels.
-// Annotations take precedence over labels because we encourage users to use annotations instead of
-// labels in this case since. Labels are more impactful to etcd since they are indexed, and we don't
-// need indexing here so we prefer annotations. However, we support labels because not all cloud
-// providers support customizing annotations on Node pools/groups. Not even KinD supports it.
-//
-// The ServiceAccount reference is retrieved from the following pair of annotations or labels:
-//
-//	{nodeAPIGroup}/serviceAccountName
-//
-//	{nodeAPIGroup}/serviceAccountNamespace
-//
-// Only Pods running on the host network should use this ServiceAccount.
-func ReferenceFromNode(node *corev1.Node) *Reference {
-	if ref := getServiceAccountReference(node.Annotations); ref != nil {
-		return ref
-	}
-	if ref := getServiceAccountReference(node.Labels); ref != nil {
-		return ref
-	}
-	return nil
-}
-
 // ReferenceFromToken returns a ServiceAccount reference from a ServiceAccount Token.
 func ReferenceFromToken(token string) *Reference {
 	tok, _, _ := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
@@ -85,25 +62,4 @@ func GoogleServiceAccountEmail(sa *corev1.ServiceAccount) (*string, error) {
 		return nil, ErrGKEAnnotationInvalid
 	}
 	return &v, nil
-}
-
-func getServiceAccountReference(m map[string]string) *Reference {
-	if m == nil {
-		return nil
-	}
-	name, ok := m[api.AnnotationServiceAccountName]
-	if !ok {
-		return nil
-	}
-	namespace, ok := m[api.AnnotationServiceAccountNamespace]
-	if !ok {
-		return nil
-	}
-	if name == "" || namespace == "" {
-		return nil
-	}
-	return &Reference{
-		Name:      name,
-		Namespace: namespace,
-	}
 }

--- a/internal/serviceaccounttokens/cache/provider.go
+++ b/internal/serviceaccounttokens/cache/provider.go
@@ -26,7 +26,6 @@ type Provider struct {
 	serviceAccounts               map[serviceaccounts.Reference]*serviceAccount
 	googleIDTokens                map[googleIDTokenReference]*tokenAndExpiration[string]
 	googleScopedAccessTokens      map[googleScopedAccessTokenReference]*tokenAndExpiration[string]
-	nodeServiceAccountRef         *serviceaccounts.Reference
 	ctx                           context.Context
 	cancelCtx                     context.CancelFunc
 	serviceAccountsMutex          sync.Mutex

--- a/internal/serviceaccounttokens/cache/service_accounts.go
+++ b/internal/serviceaccounttokens/cache/service_accounts.go
@@ -13,7 +13,6 @@ import (
 type serviceAccount struct {
 	serviceaccounts.Reference
 	podCount         int
-	usedByNode       bool
 	deleted          bool
 	tokens           *tokens
 	externalRequests chan chan<- *tokensAndError
@@ -24,8 +23,7 @@ func (p *Provider) getTokens(ctx context.Context, ref *serviceaccounts.Reference
 	sa, ok := p.serviceAccounts[*ref]
 	if !ok {
 		const podCount = 0
-		const usedByNode = false
-		sa = p.addServiceAccount(ref, podCount, usedByNode)
+		sa = p.addServiceAccount(ref, podCount)
 	} else if sa.deleted {
 		p.serviceAccountsMutex.Unlock()
 		return nil, errServiceAccountDeleted
@@ -75,11 +73,10 @@ func (s *serviceAccount) requestTokens(reqCtx, providerCtx context.Context) (*to
 	}
 }
 
-func (p *Provider) addServiceAccount(ref *serviceaccounts.Reference, podCount int, usedByNode bool) *serviceAccount {
+func (p *Provider) addServiceAccount(ref *serviceaccounts.Reference, podCount int) *serviceAccount {
 	sa := &serviceAccount{
 		Reference:        *ref,
 		podCount:         podCount,
-		usedByNode:       usedByNode,
 		externalRequests: make(chan chan<- *tokensAndError, 1),
 	}
 	p.serviceAccounts[sa.Reference] = sa
@@ -104,8 +101,7 @@ func (p *Provider) AddPodServiceAccount(ref *serviceaccounts.Reference) {
 	}
 
 	const podCount = 1
-	const usedByNode = false
-	p.addServiceAccount(ref, podCount, usedByNode)
+	p.addServiceAccount(ref, podCount)
 }
 
 func (p *Provider) DeletePodServiceAccount(ref *serviceaccounts.Reference) {
@@ -115,50 +111,6 @@ func (p *Provider) DeletePodServiceAccount(ref *serviceaccounts.Reference) {
 	if sa, ok := p.serviceAccounts[*ref]; ok && sa.podCount > 0 {
 		sa.podCount--
 	}
-}
-
-func (p *Provider) UpdateNodeServiceAccount(ref *serviceaccounts.Reference) {
-	p.serviceAccountsMutex.Lock()
-	defer p.serviceAccountsMutex.Unlock()
-
-	// if both are nil, nothing to do
-	if p.nodeServiceAccountRef == nil && ref == nil {
-		return
-	}
-
-	// if ref is nil, we must delete the current node service account
-	if ref == nil {
-		if sa, ok := p.serviceAccounts[*p.nodeServiceAccountRef]; ok {
-			sa.usedByNode = false
-		}
-		p.nodeServiceAccountRef = nil
-		return
-	}
-
-	// non-nil ref. is the current node service account also non-nil?
-	if cur := p.nodeServiceAccountRef; cur != nil {
-		// yes. if they are the same, nothing to do
-		if *cur == *ref {
-			return
-		}
-		// yes, but they are different. we must delete the current node service account
-		if sa, ok := p.serviceAccounts[*cur]; ok {
-			sa.usedByNode = false
-		}
-	}
-	p.nodeServiceAccountRef = ref
-
-	// does the new node service account exist?
-	if sa, ok := p.serviceAccounts[*ref]; ok {
-		// yes. mark it as used by the node pool and that's it
-		sa.usedByNode = true
-		return
-	}
-
-	// no. create it and mark it as used by the node pool
-	const podCount = 0
-	const usedByNode = true
-	p.addServiceAccount(ref, podCount, usedByNode)
 }
 
 func (p *Provider) UpdateServiceAccount(ref *serviceaccounts.Reference) {
@@ -197,7 +149,7 @@ func (p *Provider) checkIfMustDeleteAndDelete(sa *serviceAccount) bool {
 	p.serviceAccountsMutex.Lock()
 	defer p.serviceAccountsMutex.Unlock()
 
-	if (sa.podCount == 0 && !sa.usedByNode) || sa.deleted {
+	if sa.podCount == 0 || sa.deleted {
 		delete(p.serviceAccounts, sa.Reference)
 		p.numTokens.Dec()
 		return true

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	watchnode "github.com/matheuscscp/gke-metadata-server/internal/node/watch"
 	listpods "github.com/matheuscscp/gke-metadata-server/internal/pods/list"
 	watchpods "github.com/matheuscscp/gke-metadata-server/internal/pods/watch"
+	"github.com/matheuscscp/gke-metadata-server/internal/proxytest"
 	"github.com/matheuscscp/gke-metadata-server/internal/routing"
 	"github.com/matheuscscp/gke-metadata-server/internal/server"
 	getserviceaccount "github.com/matheuscscp/gke-metadata-server/internal/serviceaccounts/get"
@@ -70,6 +71,7 @@ func main() {
 		podLookupMaxAttempts                int
 		podLookupRetryInitialDelay          time.Duration
 		podLookupRetryMaxDelay              time.Duration
+		testProxyUpstream                   bool
 	)
 
 	flags := pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
@@ -114,6 +116,8 @@ func main() {
 		"Initial delay for retrying pod lookups upon failures")
 	flags.DurationVar(&podLookupRetryMaxDelay, "pod-lookup-retry-max-delay", 30*time.Second,
 		"Maximum delay for retrying pod lookups upon failures")
+	flags.BoolVar(&testProxyUpstream, "test-proxy-upstream", false,
+		"Test-only: in eBPF mode, bind 169.254.169.254 to lo and serve a marker on port 80 to e2e-test the proxy passthrough chain. Has no effect outside eBPF mode. Do not enable in production.")
 
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		if errors.Is(err, pflag.ErrHelp) {
@@ -319,6 +323,18 @@ func main() {
 		"routing":    routingMode,
 		"serverAddr": serverAddr,
 	}).Info("routing mode loaded and attached")
+
+	// test-only: bring up the proxy-passthrough marker upstream on lo so the
+	// e2e suite can prove the cgroup-ID self-exemption + userspace forward
+	// chain is wired up. Only active in eBPF mode; in Loopback mode the
+	// daemon already binds 169.254.169.254:80 so a second bind would fail,
+	// and in None mode the redirect path the test exercises doesn't exist.
+	if testProxyUpstream && routingMode == api.RoutingModeBPF {
+		if err := proxytest.Start(); err != nil {
+			l.WithError(err).Fatal("error starting test proxy upstream")
+		}
+		l.Info("test proxy upstream listening on 169.254.169.254:80")
+	}
 
 	// start server
 	s := server.New(ctx, server.ServerOptions{

--- a/main.go
+++ b/main.go
@@ -254,9 +254,6 @@ func main() {
 		if wp != nil {
 			wp.AddListener(p)
 		}
-		if wn != nil {
-			wn.AddListener(p)
-		}
 		if wsa != nil {
 			wsa.AddListener(p)
 		}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/matheuscscp/gke-metadata-server/api"
+	attestbpf "github.com/matheuscscp/gke-metadata-server/internal/attestation/bpf"
+	"github.com/matheuscscp/gke-metadata-server/internal/attestation/sockdiag"
 	"github.com/matheuscscp/gke-metadata-server/internal/googlecredentials"
 	"github.com/matheuscscp/gke-metadata-server/internal/logging"
 	"github.com/matheuscscp/gke-metadata-server/internal/loopback"
@@ -291,6 +293,31 @@ func main() {
 		serverAddr = loopback.GKEMetadataServerAddr
 	}
 
+	// Pick the per-mode attestation strategy. eBPF mode loads a sockops
+	// program that records every active TCP connect's 4-tuple -> cgroup ID,
+	// which userspace resolves to a pod UID by walking /sys/fs/cgroup.
+	// Loopback and None modes use a userspace netlink SOCK_DIAG fallback
+	// that resolves a 4-tuple to the owning socket's inode, walks
+	// /proc/<pid>/fd to find the PID, then reads /proc/<pid>/cgroup. The
+	// server consults this lookuper for hostNetwork pods (and, in eBPF
+	// mode, for every pod).
+	var attestationLookuper server.AttestationLookuper
+	switch routingMode {
+	case api.RoutingModeBPF:
+		attestMap, err := attestbpf.LoadAndAttach()
+		if err != nil {
+			l.WithError(err).Fatal("error loading attestation eBPF program")
+		}
+		defer func() {
+			if err := attestMap.Close(); err != nil {
+				l.WithError(err).Error("error closing attestation eBPF program")
+			}
+		}()
+		attestationLookuper = attestMap
+	case api.RoutingModeLoopback, api.RoutingModeNone:
+		attestationLookuper = sockdiag.New()
+	}
+
 	l.WithFields(logrus.Fields{
 		"routing":    routingMode,
 		"serverAddr": serverAddr,
@@ -303,7 +330,6 @@ func main() {
 		Addr:                 serverAddr,
 		HealthPort:           healthPort,
 		Pods:                 pods,
-		Node:                 node,
 		ServiceAccounts:      serviceAccounts,
 		ServiceAccountTokens: serviceAccountTokens,
 		MetricsRegistry:      metricsRegistry,
@@ -311,6 +337,7 @@ func main() {
 		NumericProjectID:     numericProjectID,
 		WorkloadIdentityPool: workloadIdentityPool,
 		RoutingMode:          routingMode,
+		Attestation:          attestationLookuper,
 		PodLookup: server.PodLookupOptions{
 			MaxAttempts:       podLookupMaxAttempts,
 			RetryInitialDelay: podLookupRetryInitialDelay,

--- a/main_test.go
+++ b/main_test.go
@@ -126,24 +126,14 @@ func TestEndToEnd(t *testing.T) {
 						"node.gke-metadata-server.matheuscscp.io/routingMode": "None",
 					},
 				},
-				// for host network pods the service account is retrieved from the node
+				// hostNetwork pods now get their own per-pod identity via kernel
+				// attestation rather than inheriting the node-level SA.
 				{
 					name:               "test-host-network",
-					serviceAccountName: "",
+					serviceAccountName: "test-impersonated",
 					hostNetwork:        true,
 					nodeSelector: map[string]string{
-						"hasRoutingMode":    "true",
-						"hasServiceAccount": "true",
-					},
-				},
-				{
-					name:               "test-host-network-on-node-without-service-account",
-					serviceAccountName: "",
-					hostNetwork:        true,
-					expectedExitCode:   1,
-					nodeSelector: map[string]string{
-						"hasRoutingMode":    "true",
-						"hasServiceAccount": "false",
+						"hasRoutingMode": "true",
 					},
 				},
 			},

--- a/main_test.go
+++ b/main_test.go
@@ -126,8 +126,8 @@ func TestEndToEnd(t *testing.T) {
 						"node.gke-metadata-server.matheuscscp.io/routingMode": "None",
 					},
 				},
-				// hostNetwork pods now get their own per-pod identity via kernel
-				// attestation rather than inheriting the node-level SA.
+				// hostNetwork pods are resolved via kernel attestation, not
+				// source IP, so they get a per-pod identity.
 				{
 					name:               "test-host-network",
 					serviceAccountName: "test-impersonated",

--- a/main_test.go
+++ b/main_test.go
@@ -90,18 +90,22 @@ func TestEndToEnd(t *testing.T) {
 			name:           "timoni with watch",
 			emulatorValues: "timoni.cue",
 			pods: []pod{
+				// Each (routing mode, pod kind) combination has exactly one
+				// dedicated test pod, pinned to the node with the matching
+				// routing mode, so every supported attestation path is
+				// exercised deterministically.
 				{
 					name:               "test-impersonation",
 					serviceAccountName: "test-impersonated",
 					nodeSelector: map[string]string{
-						"hasRoutingMode": "true",
+						"node.gke-metadata-server.matheuscscp.io/routingMode": "eBPF",
 					},
 				},
 				{
 					name:               "test-direct-access",
 					serviceAccountName: "test",
 					nodeSelector: map[string]string{
-						"hasRoutingMode": "true",
+						"node.gke-metadata-server.matheuscscp.io/routingMode": "eBPF",
 					},
 				},
 				{
@@ -109,7 +113,7 @@ func TestEndToEnd(t *testing.T) {
 					file:               "pod-gcloud.yaml",
 					serviceAccountName: "test",
 					nodeSelector: map[string]string{
-						"hasRoutingMode": "true",
+						"node.gke-metadata-server.matheuscscp.io/routingMode": "eBPF",
 					},
 				},
 				{
@@ -126,14 +130,45 @@ func TestEndToEnd(t *testing.T) {
 						"node.gke-metadata-server.matheuscscp.io/routingMode": "None",
 					},
 				},
-				// hostNetwork pods are resolved via kernel attestation, not
-				// source IP, so they get a per-pod identity.
+				// hostNetwork pods on each routing mode. The eBPF case exercises
+				// the BPF sockops attestation map; Loopback and None exercise
+				// the netlink SOCK_DIAG + /proc walk fallback.
 				{
-					name:               "test-host-network",
+					name:               "test-host-network-ebpf",
 					serviceAccountName: "test-impersonated",
 					hostNetwork:        true,
 					nodeSelector: map[string]string{
-						"hasRoutingMode": "true",
+						"node.gke-metadata-server.matheuscscp.io/routingMode": "eBPF",
+					},
+				},
+				// Second hostNetwork pod on the SAME eBPF node bound to a
+				// different ServiceAccount. Both share the node IP, so the
+				// pre-attestation source-IP path would have collapsed them to
+				// a single identity. Both succeeding concurrently with their
+				// own SAs is the canonical proof that kernel attestation
+				// disambiguates hostNetwork pods.
+				{
+					name:               "test-host-network-ebpf-disambig",
+					serviceAccountName: "test",
+					hostNetwork:        true,
+					nodeSelector: map[string]string{
+						"node.gke-metadata-server.matheuscscp.io/routingMode": "eBPF",
+					},
+				},
+				{
+					name:               "test-host-network-loopback",
+					serviceAccountName: "test-impersonated",
+					hostNetwork:        true,
+					nodeSelector: map[string]string{
+						"node.gke-metadata-server.matheuscscp.io/routingMode": "Loopback",
+					},
+				},
+				{
+					name:               "test-host-network-none",
+					serviceAccountName: "test-impersonated",
+					hostNetwork:        true,
+					nodeSelector: map[string]string{
+						"node.gke-metadata-server.matheuscscp.io/routingMode": "None",
 					},
 				},
 			},
@@ -325,7 +360,6 @@ func applyPods(t *testing.T, pods []pod) {
 		var noneRoutingEnv string
 		if p.nodeSelector["node.gke-metadata-server.matheuscscp.io/routingMode"] == "None" {
 			noneRoutingEnv = `
-    env:
     - name: HOST_IP
       valueFrom:
         fieldRef:
@@ -337,8 +371,7 @@ func applyPods(t *testing.T, pods []pod) {
     - name: GCE_METADATA_ROOT
       value: "$(HOST_IP):$(GKE_METADATA_SERVER_PORT)"
     - name: GCE_METADATA_IP
-      value: "$(HOST_IP):$(GKE_METADATA_SERVER_PORT)"
-`
+      value: "$(HOST_IP):$(GKE_METADATA_SERVER_PORT)"`
 		}
 		var nodeSelector string
 		if len(p.nodeSelector) > 0 {
@@ -354,7 +387,7 @@ func applyPods(t *testing.T, pods []pod) {
 		pod = strings.ReplaceAll(pod, "<SERVICE_ACCOUNT>", serviceAccountName)
 		pod = strings.ReplaceAll(pod, "<HOST_NETWORK>", fmt.Sprint(p.hostNetwork))
 		pod = strings.ReplaceAll(pod, "<GO_TEST_DIGEST>", fmt.Sprint(goTestDigest))
-		pod = strings.ReplaceAll(pod, "<NONE_ROUTING_ENV>", noneRoutingEnv)
+		pod = strings.ReplaceAll(pod, "<EXTRA_ENV>", noneRoutingEnv)
 		pod = strings.ReplaceAll(pod, "<NODE_SELECTOR>", nodeSelector)
 
 		// apply

--- a/main_test.go
+++ b/main_test.go
@@ -373,6 +373,15 @@ func applyPods(t *testing.T, pods []pod) {
     - name: GCE_METADATA_IP
       value: "$(HOST_IP):$(GKE_METADATA_SERVER_PORT)"`
 		}
+		// On pods pinned to eBPF nodes, signal that the daemon's --test-proxy-upstream
+		// marker server is reachable so TestProxyPassthrough can issue a hard
+		// assertion rather than skipping. Pods not pinned to eBPF skip the test.
+		var ebpfEnv string
+		if p.nodeSelector["node.gke-metadata-server.matheuscscp.io/routingMode"] == "eBPF" {
+			ebpfEnv = `
+    - name: EXPECT_PROXY_UPSTREAM
+      value: "true"`
+		}
 		var nodeSelector string
 		if len(p.nodeSelector) > 0 {
 			var b strings.Builder
@@ -387,7 +396,7 @@ func applyPods(t *testing.T, pods []pod) {
 		pod = strings.ReplaceAll(pod, "<SERVICE_ACCOUNT>", serviceAccountName)
 		pod = strings.ReplaceAll(pod, "<HOST_NETWORK>", fmt.Sprint(p.hostNetwork))
 		pod = strings.ReplaceAll(pod, "<GO_TEST_DIGEST>", fmt.Sprint(goTestDigest))
-		pod = strings.ReplaceAll(pod, "<EXTRA_ENV>", noneRoutingEnv)
+		pod = strings.ReplaceAll(pod, "<EXTRA_ENV>", noneRoutingEnv+ebpfEnv)
 		pod = strings.ReplaceAll(pod, "<NODE_SELECTOR>", nodeSelector)
 
 		// apply

--- a/testdata/helm.yaml
+++ b/testdata/helm.yaml
@@ -4,6 +4,7 @@
 config:
   projectID: gke-metadata-server
   workloadIdentityProvider: projects/637293746831/locations/global/workloadIdentityPools/test-kind-cluster/providers/<TEST_ID>
+  testProxyUpstream: true
 
 image:
   repository: ghcr.io/matheuscscp/gke-metadata-server/test

--- a/testdata/kind.yaml
+++ b/testdata/kind.yaml
@@ -9,26 +9,20 @@ nodes:
   labels:
     iam.gke.io/gke-metadata-server-enabled: "true"
     node.gke-metadata-server.matheuscscp.io/routingMode: eBPF
-    node.gke-metadata-server.matheuscscp.io/serviceAccountName: test-impersonated
-    node.gke-metadata-server.matheuscscp.io/serviceAccountNamespace: default
     hasRoutingMode: "true"
-    hasServiceAccount: "true"
 - role: worker
   labels:
     iam.gke.io/gke-metadata-server-enabled: "true"
     node.gke-metadata-server.matheuscscp.io/routingMode: Loopback
     hasRoutingMode: "true"
-    hasServiceAccount: "false"
 - role: worker
   labels:
     iam.gke.io/gke-metadata-server-enabled: "true"
     node.gke-metadata-server.matheuscscp.io/routingMode: None
     hasRoutingMode: "false"
-    hasServiceAccount: "false"
 - role: worker
   labels:
     allNodesTest: "true"
     hasRoutingMode: "false"
-    hasServiceAccount: "false"
 networking:
   disableDefaultCNI: true

--- a/testdata/pod.yaml
+++ b/testdata/pod.yaml
@@ -56,4 +56,13 @@ spec:
   containers:
   - name: test
     image: ghcr.io/matheuscscp/gke-metadata-server/test@<GO_TEST_DIGEST>
-<NONE_ROUTING_ENV><NODE_SELECTOR>
+    env:
+    # POD_NAME is exposed via the downward API because hostNetwork pods
+    # share the host's UTS namespace — their HOSTNAME is the node name,
+    # not the pod name. Tests that branch on which pod they're running
+    # in must read POD_NAME instead of HOSTNAME.
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name<EXTRA_ENV>
+<NODE_SELECTOR>

--- a/testdata/timoni-all-nodes.cue
+++ b/testdata/timoni-all-nodes.cue
@@ -8,6 +8,7 @@ values: requireNodeLabel: false
 values: settings: {
 	projectID:                "gke-metadata-server"
 	workloadIdentityProvider: "projects/637293746831/locations/global/workloadIdentityPools/test-kind-cluster/providers/<TEST_ID>"
+	testProxyUpstream:        true
 }
 
 values: image: {

--- a/testdata/timoni-no-watch.cue
+++ b/testdata/timoni-no-watch.cue
@@ -10,6 +10,7 @@ values: settings: {
 	watchNode:                enable: false
 	watchServiceAccounts:     enable: false
 	cacheTokens:              enable: false
+	testProxyUpstream:        true
 }
 
 values: image: {

--- a/testdata/timoni.cue
+++ b/testdata/timoni.cue
@@ -6,6 +6,7 @@ package main
 values: settings: {
 	projectID:                "gke-metadata-server"
 	workloadIdentityProvider: "projects/637293746831/locations/global/workloadIdentityPools/test-kind-cluster/providers/<TEST_ID>"
+	testProxyUpstream:        true
 }
 
 values: image: {

--- a/timoni/gke-metadata-server/templates/daemonset.cue
+++ b/timoni/gke-metadata-server/templates/daemonset.cue
@@ -24,7 +24,14 @@ import (
 				}
 			}
 			spec: {
-				hostNetwork:        true
+				hostNetwork: true
+				// hostPID is required by the netlink SOCK_DIAG fallback used in
+				// Loopback and None routing modes for hostNetwork pods: the
+				// server walks /proc/<pid>/fd to map a socket inode back to its
+				// owning PID, then reads /proc/<pid>/cgroup to derive the pod
+				// UID. eBPF mode does not need it (cgroup ID alone identifies
+				// the pod).
+				hostPID:            true
 				serviceAccountName: #config.#namespacedMetadata.name
 				priorityClassName:  "system-node-critical"
 				affinity: nodeAffinity: requiredDuringSchedulingIgnoredDuringExecution: nodeSelectorTerms: [{

--- a/timoni/gke-metadata-server/templates/daemonset.cue
+++ b/timoni/gke-metadata-server/templates/daemonset.cue
@@ -126,6 +126,9 @@ import (
 						if #config.settings.podLookup.retryMaxDelay != _|_ {
 							"--pod-lookup-retry-max-delay=\(#config.settings.podLookup.retryMaxDelay)"
 						}
+						if #config.settings.testProxyUpstream {
+							"--test-proxy-upstream"
+						}
 					]
 					env: [
 						{

--- a/timoni/gke-metadata-server/templates/settings.cue
+++ b/timoni/gke-metadata-server/templates/settings.cue
@@ -58,6 +58,12 @@ import (
 		retryMaxDelay?: time.Duration
 	}
 
+	// testProxyUpstream is a TEST-ONLY flag. When true, in eBPF routing mode the
+	// daemon binds 169.254.169.254 to lo and serves a marker on port 80 to allow
+	// the project's e2e suite to assert the proxy-passthrough chain is wired up.
+	// Has no effect outside eBPF mode. Do not enable in production.
+	testProxyUpstream: bool | *false
+
 	// Helper definitions.
 	#watchSettings: {
 		// enable is a flag to enable the watch feature.


### PR DESCRIPTION
Closes #488. Closes #490.

**⚠️ Breaking Change**: The annotation pair for assigning a ServiceAccount to a node is now removed. This PR improves the emulator's ability to identity client pods, including those on the host network (i.e. those with `.spec.hostNetwork` set to `true`). This means pods on the host network are no longer indistinguishable from each other, which means they can get tokens for their own ServiceAccounts.

Replaces the source-IP based pod attestation with a kernel-attested chain so hostNetwork pods get per-pod identities (instead of inheriting the node-level service account) and non-hostNetwork pods get a stronger guarantee than "the IP we see is unforgeable".

## How it works

Each (routing mode, pod kind) has exactly one resolution strategy — no fallbacks.

| mode | non-hostNetwork pod | hostNetwork pod |
|---|---|---|
| eBPF | sockops 4-tuple → cgroup ID → pod UID | same |
| Loopback | source IP → `GetByIP` | netlink SOCK_DIAG → /proc → cgroup → pod UID |
| None | source IP → `GetByIP` | netlink SOCK_DIAG → /proc → cgroup → pod UID |

- **eBPF**: a `cgroup/sock_ops` program records the connecting task's cgroup ID at `BPF_SOCK_OPS_TCP_CONNECT_CB` into a 4-tuple-keyed LRU hash map. Userspace looks up the 4-tuple from `conn.RemoteAddr` plus the daemon's bind address, walks `/sys/fs/cgroup` to find the directory whose inode matches, and extracts the pod UID from the kubelet's `pod<UID>` cgroup naming convention. Cgroup IDs are kernel-attested, namespace-independent, and not reused once a pod cgroup is destroyed.
- **Loopback / None**: hostNetwork pods share the host netns so the active socket is visible to a `NETLINK_SOCK_DIAG` query on the host. We resolve the 4-tuple to its socket inode, walk `/proc/<pid>/fd` to find the owning PID, then read `/proc/<pid>/cgroup` for the same `pod<UID>` extraction. Non-hostNetwork pods use the existing `GetByIP` (their pod IP is unique per node and `GetByIP` is node-scoped, so it's already a sound attestation).
- The pre-existing `getNodeServiceAccountReference` path that gave hostNetwork pods the node-level SA is removed entirely.

## Other things in this PR

- **Cgroup-ID self-identification for the proxy passthrough**: the existing eBPF redirect program no longer relies on the magic-IP PID-discovery dance to recognise the daemon's own outbound connections. It now compares `bpf_get_current_cgroup_id()` against the daemon's cgroup inode (read at startup from `/proc/self/cgroup`). No observable side channel during startup, no PID-reuse window.
- **`GetByUID` on the pods provider**: cache (UID-indexed informer) and list-provider implementations. The watch informer's `spec.hostNetwork=false` filter is removed; hostNetwork pods are now in the cache but skipped from the IP index (so they don't pollute `GetByIP` lookups).
- **`hostPID: true`** on the daemonset (helm + timoni) so `/proc/<pid>` resolution works for the sockdiag path.

## Test coverage

- **Per-mode happy paths**: one pinned test pod per `(routing mode, pod kind)` combination — 6 in total — so every supported attestation strategy is exercised on every CI run.
- **hostNetwork disambiguation**: a second hostNetwork pod on the same eBPF node bound to a different ServiceAccount. Both share the node IP, so the pre-attestation source-IP path would have collapsed them to a single identity — the test passes only because kernel attestation distinguishes them.
- **Proxy passthrough end-to-end**: an opt-in `--test-proxy-upstream` flag (off by default, plumbed via helm and timoni) brings up an in-daemon HTTP marker server bound to `169.254.169.254:80` on lo. Test pods on eBPF nodes GET a non-metadata path on `169.254.169.254` and assert the marker, exercising both the `cgroup/connect4` self-exemption (the daemon's own dial reaches the upstream instead of being redirected back to itself) and the userspace sniff/forward end-to-end. Closes #490.

## Compatibility

- **Kernel ≥ 5.5** (CO-RE on `task->start_boottime` is no longer needed since we use cgroup ID; `bpf_get_current_cgroup_id` since 4.18, sockops since 4.13).
- **Cgroup v2** unified hierarchy. Mixed v1+v2 systems with the v2 line are fine; pure v1 is unsupported.
- **Cilium** as the CNI — tested locally with Cilium 1.19.3 in default kind config. Other CNIs untested.
- **Sandboxed runtimes** (gVisor, Kata) are unsupported by design — their userspace kernels are invisible to host BPF.

## Test plan

- [x] CI passes
- [x] Local e2e all 4 sub-tests pass on a kind cluster with Cilium 1.19.3
