### PR TITLE
Run CI on a CNI matrix and drop OCI artifacts from PR validation

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,13 +12,26 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  pull-request:
+  e2e:
+    # Matrix axis: which CNI / Cilium configuration the kind cluster runs.
+    # cilium-default is the historical setup; cilium-kpr exercises Cilium's
+    # kube-proxy-replacement (validates multi-attach coexistence with our
+    # cgroup/connect4 redirect program); kindnet validates the README's "no
+    # specific CNI required" claim by running on kind's default CNI.
+    #
+    # The aggregator job below is the one wired up to branch protection as
+    # the required `pull-request` status check; this matrix job is what
+    # actually runs the work.
+    strategy:
+      fail-fast: false
+      matrix:
+        cni: [cilium-default, cilium-kpr, kindnet]
+    name: e2e (${{ matrix.cni }})
     runs-on: ubuntu-latest
     environment: pull-request
     permissions:
       contents: read
       id-token: write
-      packages: write
       pull-requests: write
 
     steps:
@@ -66,8 +79,30 @@ jobs:
         if [ -n "$TOOLS_DIR" ]; then
           sudo ln -sfn "$TOOLS_DIR" "/usr/lib/linux-tools/$(uname -r)"
         fi
-    - name: Set version
-      run: echo "100.0.0-ci" > version.txt
-    - run: make gen-ebpf ci-cluster build build-go-test ci-test
+    # Pipeline order is intentional:
+    #   ci-cluster (kind + GCP provider) → build (local docker image, ~30-60s,
+    #   acts as the GCP-propagation buffer) → build-go-test (same) →
+    #   kind-load-images → ci-test. Container images are built locally and
+    #   loaded into kind's containerd; nothing is pushed to a registry for
+    #   PR validation.
+    - run: make gen-ebpf ci-cluster build build-go-test kind-load-images ci-test
       env:
         PLATFORMS: linux/amd64
+        CNI: ${{ matrix.cni }}
+
+  # Aggregator wired up as the required `pull-request` status check in branch
+  # protection. Runs after every matrix entry regardless of their outcome
+  # (`if: always()`) and fails iff any matrix entry didn't succeed. This way
+  # the required-checks list stays a single name independent of how many CNI
+  # configurations the matrix grows to.
+  pull-request:
+    needs: e2e
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify all matrix entries succeeded
+      run: |
+        if [ "${{ needs.e2e.result }}" != "success" ]; then
+          echo "e2e matrix result: ${{ needs.e2e.result }}"
+          exit 1
+        fi

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,30 @@
 
 SHELL := /bin/bash
 
-TEST_IMAGE := ghcr.io/matheuscscp/gke-metadata-server/test
+# Exported so recursive sub-make recipes see CNI in their shell environment
+# (Make doesn't auto-export command-line variables otherwise).
+export CNI
+
+# Local-only image refs used by CI and dev builds. Pods reference these by
+# tag with imagePullPolicy: Never; images are loaded into the kind cluster
+# via `kind load docker-image`. No registry push happens for PR validation
+# — release.yaml has its own inline OCI push to the production registry.
+LOCAL_IMAGE := gke-metadata-server-test
+LOCAL_TAG_DAEMON := container
+LOCAL_TAG_GOTEST := go-test
+# Helm/Timoni need a valid SemVer for chart/module metadata; the value is
+# only used as a string label in PR-mode applies (filesystem-based, not OCI).
+LOCAL_VERSION := 0.0.0-dev
 PLATFORMS ?= linux/amd64
 CILIUM_VERSION ?= 1.19.3
 
 .PHONY: dev
-dev: tidy gen-ebpf dev-cluster build build-go-test dev-test
+dev: tidy gen-ebpf dev-cluster build build-go-test kind-load-images dev-test
 
 .PHONY: clean
 clean:
-	rm -rf *.json *.txt *.logs *.tgz
+	rm -rf *.json *.logs *.tgz ci-test-id.txt jwks.json
+	rm -f helm/gke-metadata-server/Chart.yaml timoni/gke-metadata-server/templates/config.cue
 
 .PHONY: tidy
 tidy:
@@ -63,10 +77,25 @@ ci-test:
 cluster:
 	@if [ "${TEST_ID}" == "" ]; then echo "TEST_ID variable is required."; exit -1; fi
 	@if [ "${PROVIDER_COMMAND}" == "" ]; then echo "PROVIDER_COMMAND variable is required."; exit -1; fi
-	kind create cluster --name gke-metadata-server --config testdata/kind.yaml
+	# CNI selects the kind config and whether to install Cilium:
+	#   cilium-default (default): testdata/kind.yaml + Cilium 1.19.x default settings.
+	#   cilium-kpr:               testdata/kind-cilium-kpr.yaml + Cilium with
+	#                             kubeProxyReplacement=true and bpf.masquerade=true.
+	#   kindnet:                  testdata/kind-kindnet.yaml (default kind CNI), no Cilium.
+	CNI=$${CNI:-cilium-default}; \
+	case "$$CNI" in \
+		cilium-default) KIND_CONFIG=testdata/kind.yaml ;; \
+		cilium-kpr)     KIND_CONFIG=testdata/kind-cilium-kpr.yaml ;; \
+		kindnet)        KIND_CONFIG=testdata/kind-kindnet.yaml ;; \
+		*) echo "unknown CNI=$$CNI"; exit 1 ;; \
+	esac; \
+	kind create cluster --name gke-metadata-server --config $$KIND_CONFIG
 	kubectl --context kind-gke-metadata-server get nodes -o custom-columns="NODE:.metadata.name,ROUTING MODE:.metadata.labels['node\.gke-metadata-server\.matheuscscp\.io/routingMode']"
 	make create-or-update-provider TEST_ID=${TEST_ID} PROVIDER_COMMAND=${PROVIDER_COMMAND}
-	make install-cilium
+	@CNI=$${CNI:-cilium-default}; \
+	if [ "$$CNI" != "kindnet" ]; then \
+		make install-cilium CNI=$$CNI; \
+	fi
 
 .PHONY: create-or-update-provider
 create-or-update-provider:
@@ -88,47 +117,66 @@ install-cilium:
 	helm repo add cilium https://helm.cilium.io/
 	docker pull quay.io/cilium/cilium:v$(CILIUM_VERSION)
 	kind load docker-image --name gke-metadata-server quay.io/cilium/cilium:v$(CILIUM_VERSION)
+	# CNI=cilium-kpr enables Cilium's kubeProxyReplacement (kube-proxy is
+	# disabled in the kind config via kubeProxyMode: "none"). This validates
+	# coexistence with Cilium's own cgroup/connect4 program — Cilium attaches
+	# one for service-VIP redirection, ours attaches one for the metadata-IP
+	# rewrite, and the two must run together via cilium/ebpf's BPF_LINK_CREATE
+	# multi-attach. bpf.masquerade is intentionally NOT enabled: it requires
+	# additional Cilium config (ipv4NativeRoutingCIDR etc.) to keep egress
+	# DNS working in kind, and it's orthogonal to what this matrix entry is
+	# validating.
+	@CNI=$${CNI:-cilium-default}; \
+	if [ "$$CNI" = "cilium-kpr" ]; then \
+		KPR_FLAGS="--set kubeProxyReplacement=true \
+			--set k8sServiceHost=gke-metadata-server-control-plane \
+			--set k8sServicePort=6443"; \
+	else \
+		KPR_FLAGS=""; \
+	fi; \
 	helm install cilium cilium/cilium --version $(CILIUM_VERSION) \
 		--namespace kube-system \
 		--set image.pullPolicy=IfNotPresent \
-		--set ipam.mode=kubernetes
-
-.PHONY: build-dev
-build-dev:
-	docker buildx build . --platform linux/amd64,linux/arm64 -t ${TEST_IMAGE}:${TAG} --push
+		--set ipam.mode=kubernetes \
+		$$KPR_FLAGS
 
 .PHONY: build
+# Builds the daemon container image into the local Docker daemon and renders
+# the Helm chart / Timoni module metadata so they are valid for filesystem
+# applies. Nothing is pushed to a registry; CI loads the local image into
+# the kind cluster via `make kind-load-images` and applies helm/timoni from
+# their on-disk paths. Release-mode OCI publishing is handled inline by
+# .github/workflows/release.yaml.
 build:
-	docker buildx build . --platform ${PLATFORMS} -t ${TEST_IMAGE}:container --push \
-		--metadata-file container-metadata.json
-	jq -r '."containerimage.digest"' container-metadata.json > container-digest.txt
-
-	sed "s|<HELM_VERSION>|$$(cat version.txt)|g" helm/gke-metadata-server/Chart.tpl.yaml | \
-		sed "s|<CONTAINER_VERSION>|$$(cat version.txt)|g" > helm/gke-metadata-server/Chart.yaml
+	docker buildx build . --platform ${PLATFORMS} \
+		-t ${LOCAL_IMAGE}:${LOCAL_TAG_DAEMON} --load
+	sed "s|<HELM_VERSION>|${LOCAL_VERSION}|g" helm/gke-metadata-server/Chart.tpl.yaml | \
+		sed "s|<CONTAINER_VERSION>|${LOCAL_VERSION}|g" > helm/gke-metadata-server/Chart.yaml
 	helm lint helm/gke-metadata-server
-	helm package helm/gke-metadata-server
-	helm push gke-metadata-server-helm-$$(cat version.txt).tgz oci://${TEST_IMAGE} 2>&1 | tee helm-push.logs
-	cat helm-push.logs | grep Digest: | awk '{print $$NF}' > helm-digest.txt
-
-	sed "s|<CONTAINER_VERSION>|$$(cat version.txt)|g" \
+	sed "s|<CONTAINER_VERSION>|${LOCAL_VERSION}|g" \
 		timoni/gke-metadata-server/templates/config.tpl.cue > timoni/gke-metadata-server/templates/config.cue
 	timoni mod vet timoni/gke-metadata-server/ \
 		--name gke-metadata-server \
 		--namespace kube-system \
 		--values timoni/gke-metadata-server/debug_values.cue
-	timoni mod push timoni/gke-metadata-server/ oci://${TEST_IMAGE}/timoni \
-		--version $$(cat version.txt) \
-		--output yaml | yq .digest > timoni-digest.txt
 
 .PHONY: build-go-test
 build-go-test:
 	mv .dockerignore .dockerignore.bkp
 	mv .dockerignore.test .dockerignore
-	docker buildx build . --platform ${PLATFORMS} -t ${TEST_IMAGE}:go-test -f Dockerfile.test --push \
-		--metadata-file go-test-metadata.json
+	docker buildx build . --platform ${PLATFORMS} \
+		-t ${LOCAL_IMAGE}:${LOCAL_TAG_GOTEST} -f Dockerfile.test --load
 	mv .dockerignore .dockerignore.test
 	mv .dockerignore.bkp .dockerignore
-	jq -r '."containerimage.digest"' go-test-metadata.json > go-test-digest.txt
+
+.PHONY: kind-load-images
+# Loads the locally-built daemon and test images into the kind cluster's
+# containerd. Must run after both `build` and `build-go-test` and after the
+# kind cluster is up. Pods then reference these tags directly with
+# imagePullPolicy: Never (see testdata/pod.yaml).
+kind-load-images:
+	kind load docker-image --name gke-metadata-server ${LOCAL_IMAGE}:${LOCAL_TAG_DAEMON}
+	kind load docker-image --name gke-metadata-server ${LOCAL_IMAGE}:${LOCAL_TAG_GOTEST}
 
 .PHONY: test-unit
 test-unit:
@@ -138,7 +186,11 @@ test-unit:
 .PHONY: test
 test:
 	@if [ "${TEST_ID}" == "" ]; then echo "TEST_ID variable is required."; exit -1; fi
-	TEST_ID=${TEST_ID} TEST_IMAGE=${TEST_IMAGE} HELM_VERSION=$$(cat version.txt) go test -v ${TEST_ARGS}
+	TEST_ID=${TEST_ID} \
+	LOCAL_IMAGE=${LOCAL_IMAGE} \
+	LOCAL_TAG_DAEMON=${LOCAL_TAG_DAEMON} \
+	LOCAL_TAG_GOTEST=${LOCAL_TAG_GOTEST} \
+	go test -v ${TEST_ARGS}
 
 .PHONY: update-branch
 update-branch:

--- a/README.md
+++ b/README.md
@@ -241,13 +241,15 @@ emulator consults that map for hostNetwork pod requests and resolves the cgroup
 ID to a pod UID by walking `/sys/fs/cgroup`, giving hostNetwork pods per-pod
 identity (see [Pods running on the host network](#pods-running-on-the-host-network)).
 
-This mode may have conflicts with other eBPF-based tools running in the cluster.
-It works well with a default installation of Cilium, but if you are using Cilium
-to replace `kube-proxy`
-([docs](https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/))
-then this mode will have a direct conflict with your setup, since for this Cilium
-feature to work it needs to hook to many additional points, including the `connect()`
-syscall.
+This mode coexists with other eBPF tools that attach to `cgroup/connect4` —
+notably Cilium, including with [`kubeProxyReplacement`](https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/)
+enabled (which makes Cilium attach its own `cgroup/connect4` for service-VIP
+redirection). Both programs are loaded under the same hook via the kernel's
+multi-attach API (`BPF_LINK_CREATE`), and act on disjoint destinations:
+Cilium rewrites ClusterIP-range destinations, this emulator rewrites
+`169.254.169.254:80` only. Either ordering between the two programs
+produces the same result. CI validates this coexistence on every PR
+(`e2e (cilium-kpr)` matrix entry).
 
 The advantage of this mode is that the emulator can bind to any port, not just port 80.
 This is because we modify the destination address of connections targeting our endpoint
@@ -412,9 +414,12 @@ ServiceAccount.
 
 Hard requirements: a Linux kernel with cgroup v2 unified hierarchy and BPF
 cgroup-hook support (in practice any kernel from the last few years —
-`bpf_get_current_cgroup_id` has been available since 4.18). No specific CNI
-is required; Cilium is what the project's kind test setup happens to use,
-not a runtime dependency.
+`bpf_get_current_cgroup_id` has been available since 4.18). No specific
+CNI is required. CI exercises three configurations on every PR:
+`cilium-default` (Cilium 1.19.x with default values), `cilium-kpr` (Cilium
+with `kubeProxyReplacement=true`, which makes Cilium attach its own
+`cgroup/connect4` program alongside ours), and `kindnet` (kind's default
+CNI, no Cilium).
 
 Sandboxed container runtimes (gVisor, Kata) are unsupported because their
 userspace kernels are not visible to host BPF programs and not represented

--- a/main_test.go
+++ b/main_test.go
@@ -26,23 +26,24 @@ type pod struct {
 }
 
 var (
-	// testID is used to isolate test resources.
-	testID      = os.Getenv("TEST_ID")
-	testImage   = os.Getenv("TEST_IMAGE")
-	helmVersion = os.Getenv("HELM_VERSION")
+	// testID is used to isolate the GCP workload-identity-pool provider
+	// across CI runs.
+	testID = os.Getenv("TEST_ID")
 
-	containerDigest = readDigest("container")
-	timoniDigest    = readDigest("timoni")
-	helmDigest      = readDigest("helm")
-	goTestDigest    = readDigest("go-test")
+	// localImage and the per-target tags identify the daemon and test
+	// container images that `make build`/`make build-go-test` produced
+	// locally and that `make kind-load-images` loaded into the kind nodes'
+	// containerd. Pods reference them by tag with imagePullPolicy: Never.
+	localImage     = envOrDefault("LOCAL_IMAGE", "gke-metadata-server-test")
+	localTagDaemon = envOrDefault("LOCAL_TAG_DAEMON", "container")
+	localTagGoTest = envOrDefault("LOCAL_TAG_GOTEST", "go-test")
 )
 
-func readDigest(s string) string {
-	b, err := os.ReadFile(fmt.Sprintf("%s-digest.txt", s))
-	if err != nil {
-		panic(err)
+func envOrDefault(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
 	}
-	return strings.TrimSpace(string(b))
+	return d
 }
 
 func TestEndToEnd(t *testing.T) {
@@ -245,55 +246,27 @@ func applyEmulator(t *testing.T, valuesFile string, allNodes bool) bool {
 	b, err := os.ReadFile(fmt.Sprintf("testdata/%s", valuesFile))
 	require.NoError(t, err)
 	values = strings.ReplaceAll(string(b), "<TEST_ID>", testID)
-	values = strings.ReplaceAll(values, "<CONTAINER_DIGEST>", containerDigest)
+	values = strings.ReplaceAll(values, "<LOCAL_IMAGE>", localImage)
+	values = strings.ReplaceAll(values, "<LOCAL_TAG_DAEMON>", localTagDaemon)
 
-	// detect helm or timoni
+	// Apply directly from the on-disk chart/module — no OCI push happens
+	// during PR validation (see Makefile), so there is nothing to pull.
 	var emulatorCmdName string
 	var emulatorCmdArgs []string
 	if strings.Contains(valuesFile, "helm") {
-		// remove previous helm package
-		helmPackage := fmt.Sprintf("gke-metadata-server-helm-%s.tgz", helmVersion)
-		os.Remove(helmPackage)
-
-		// pull helm package
-		cmd := exec.Command(
-			"helm",
-			"pull",
-			fmt.Sprintf("oci://%s/gke-metadata-server-helm", testImage),
-			"--version", helmVersion)
-		b, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("error pulling helm chart: %v: %s", err, string(b))
-		}
-
-		// verify helm package digest
-		var digest string
-		for _, line := range strings.Split(string(b), "\n") {
-			if strings.Contains(line, "Digest:") {
-				digest = strings.Fields(line)[1]
-				break
-			}
-		}
-		if digest != helmDigest {
-			t.Fatalf("expected helm digest %s, got %s", helmDigest, digest)
-		}
-
-		// set helm command
 		emulatorCmdName = "helm"
 		emulatorCmdArgs = []string{
 			"--kube-context", "kind-gke-metadata-server",
 			"--namespace", "kube-system",
-			"upgrade", "--install", "gke-metadata-server", helmPackage,
+			"upgrade", "--install", "gke-metadata-server", "./helm/gke-metadata-server",
 			"-f", "-",
 		}
 	} else {
-		// set timoni command
 		emulatorCmdName = "timoni"
 		emulatorCmdArgs = []string{
 			"--kube-context", "kind-gke-metadata-server",
 			"--namespace", "kube-system",
-			"apply", "gke-metadata-server", fmt.Sprintf("oci://%s/timoni", testImage),
-			"--digest", timoniDigest,
+			"apply", "gke-metadata-server", "./timoni/gke-metadata-server",
 			"-f", "-",
 		}
 	}
@@ -376,11 +349,30 @@ func applyPods(t *testing.T, pods []pod) {
 		// On pods pinned to eBPF nodes, signal that the daemon's --test-proxy-upstream
 		// marker server is reachable so TestProxyPassthrough can issue a hard
 		// assertion rather than skipping. Pods not pinned to eBPF skip the test.
+		//
+		// Also set GCE_METADATA_HOST so cloud.google.com/go/compute/metadata's
+		// OnGCE short-circuits to true without probing 169.254.169.254 — the
+		// proxy-passthrough marker server intercepts non-metadata requests on
+		// that IP and replies without `Metadata-Flavor: Google`, which races
+		// with the library's parallel DNS strategy and flakes OnGCE to false.
 		var ebpfEnv string
 		if p.nodeSelector["node.gke-metadata-server.matheuscscp.io/routingMode"] == "eBPF" {
 			ebpfEnv = `
     - name: EXPECT_PROXY_UPSTREAM
-      value: "true"`
+      value: "true"
+    - name: GCE_METADATA_HOST
+      value: "169.254.169.254"`
+		}
+		// Loopback mode binds the daemon directly to 169.254.169.254:80; the
+		// library's HTTP probe to that IP gets a metadata response from the
+		// daemon, but for paths it doesn't recognise (like `/`) it can return
+		// without the expected header and lose the OnGCE race the same way.
+		// Short-circuit it the same way as eBPF.
+		var loopbackEnv string
+		if p.nodeSelector["node.gke-metadata-server.matheuscscp.io/routingMode"] == "Loopback" {
+			loopbackEnv = `
+    - name: GCE_METADATA_HOST
+      value: "169.254.169.254"`
 		}
 		var nodeSelector string
 		if len(p.nodeSelector) > 0 {
@@ -395,8 +387,9 @@ func applyPods(t *testing.T, pods []pod) {
 		pod = strings.ReplaceAll(string(b), "<POD_NAME>", p.name)
 		pod = strings.ReplaceAll(pod, "<SERVICE_ACCOUNT>", serviceAccountName)
 		pod = strings.ReplaceAll(pod, "<HOST_NETWORK>", fmt.Sprint(p.hostNetwork))
-		pod = strings.ReplaceAll(pod, "<GO_TEST_DIGEST>", fmt.Sprint(goTestDigest))
-		pod = strings.ReplaceAll(pod, "<EXTRA_ENV>", noneRoutingEnv+ebpfEnv)
+		pod = strings.ReplaceAll(pod, "<LOCAL_IMAGE>", localImage)
+		pod = strings.ReplaceAll(pod, "<LOCAL_TAG_GOTEST>", localTagGoTest)
+		pod = strings.ReplaceAll(pod, "<EXTRA_ENV>", noneRoutingEnv+ebpfEnv+loopbackEnv)
 		pod = strings.ReplaceAll(pod, "<NODE_SELECTOR>", nodeSelector)
 
 		// apply

--- a/testdata/helm.yaml
+++ b/testdata/helm.yaml
@@ -7,5 +7,6 @@ config:
   testProxyUpstream: true
 
 image:
-  repository: ghcr.io/matheuscscp/gke-metadata-server/test
-  digest: <CONTAINER_DIGEST>
+  repository: <LOCAL_IMAGE>
+  tag: <LOCAL_TAG_DAEMON>
+  pullPolicy: Never

--- a/testdata/kind-cilium-kpr.yaml
+++ b/testdata/kind-cilium-kpr.yaml
@@ -1,0 +1,34 @@
+# Copyright 2025 Matheus Pimenta.
+# SPDX-License-Identifier: AGPL-3.0
+
+# kind cluster used by the cilium-kpr CI matrix entry: Cilium with
+# kubeProxyReplacement=true. kube-proxy is disabled in the kind cluster so
+# Cilium owns service-VIP redirection via its own cgroup/connect4 program;
+# this exercises the multi-attach coexistence with our redirect program.
+
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+- role: worker
+  labels:
+    iam.gke.io/gke-metadata-server-enabled: "true"
+    node.gke-metadata-server.matheuscscp.io/routingMode: eBPF
+    hasRoutingMode: "true"
+- role: worker
+  labels:
+    iam.gke.io/gke-metadata-server-enabled: "true"
+    node.gke-metadata-server.matheuscscp.io/routingMode: Loopback
+    hasRoutingMode: "true"
+- role: worker
+  labels:
+    iam.gke.io/gke-metadata-server-enabled: "true"
+    node.gke-metadata-server.matheuscscp.io/routingMode: None
+    hasRoutingMode: "false"
+- role: worker
+  labels:
+    allNodesTest: "true"
+    hasRoutingMode: "false"
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: "none"

--- a/testdata/kind-kindnet.yaml
+++ b/testdata/kind-kindnet.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 Matheus Pimenta.
+# SPDX-License-Identifier: AGPL-3.0
+
+# kind cluster used by the kindnet CI matrix entry: default kind CNI (kindnet),
+# default kube-proxy. Validates the README's "no specific CNI required" claim
+# by exercising the full attestation chain on a non-Cilium cluster.
+
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+- role: worker
+  labels:
+    iam.gke.io/gke-metadata-server-enabled: "true"
+    node.gke-metadata-server.matheuscscp.io/routingMode: eBPF
+    hasRoutingMode: "true"
+- role: worker
+  labels:
+    iam.gke.io/gke-metadata-server-enabled: "true"
+    node.gke-metadata-server.matheuscscp.io/routingMode: Loopback
+    hasRoutingMode: "true"
+- role: worker
+  labels:
+    iam.gke.io/gke-metadata-server-enabled: "true"
+    node.gke-metadata-server.matheuscscp.io/routingMode: None
+    hasRoutingMode: "false"
+- role: worker
+  labels:
+    allNodesTest: "true"
+    hasRoutingMode: "false"

--- a/testdata/pod.yaml
+++ b/testdata/pod.yaml
@@ -55,7 +55,8 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: test
-    image: ghcr.io/matheuscscp/gke-metadata-server/test@<GO_TEST_DIGEST>
+    image: <LOCAL_IMAGE>:<LOCAL_TAG_GOTEST>
+    imagePullPolicy: Never
     env:
     # POD_NAME is exposed via the downward API because hostNetwork pods
     # share the host's UTS namespace — their HOSTNAME is the node name,

--- a/testdata/timoni-all-nodes.cue
+++ b/testdata/timoni-all-nodes.cue
@@ -12,6 +12,7 @@ values: settings: {
 }
 
 values: image: {
-	repository: "ghcr.io/matheuscscp/gke-metadata-server/test"
-	digest:     "<CONTAINER_DIGEST>"
+	repository: "<LOCAL_IMAGE>"
+	tag:        "<LOCAL_TAG_DAEMON>"
+	pullPolicy: "Never"
 }

--- a/testdata/timoni-no-watch.cue
+++ b/testdata/timoni-no-watch.cue
@@ -14,6 +14,7 @@ values: settings: {
 }
 
 values: image: {
-	repository: "ghcr.io/matheuscscp/gke-metadata-server/test"
-	digest:     "<CONTAINER_DIGEST>"
+	repository: "<LOCAL_IMAGE>"
+	tag:        "<LOCAL_TAG_DAEMON>"
+	pullPolicy: "Never"
 }

--- a/testdata/timoni.cue
+++ b/testdata/timoni.cue
@@ -10,6 +10,7 @@ values: settings: {
 }
 
 values: image: {
-	repository: "ghcr.io/matheuscscp/gke-metadata-server/test"
-	digest:     "<CONTAINER_DIGEST>"
+	repository: "<LOCAL_IMAGE>"
+	tag:        "<LOCAL_TAG_DAEMON>"
+	pullPolicy: "Never"
 }


### PR DESCRIPTION
Adds two new CI matrix entries — Cilium with `kubeProxyReplacement=true`, and kind's default CNI (kindnet) — and refactors PR validation to skip OCI publishing entirely.

## What changes

**CNI matrix.** `pull-request.yaml` now runs the e2e suite three times in parallel:

- `cilium-default` — historical setup (Cilium 1.19.3 with default values).
- `cilium-kpr` — Cilium with `kubeProxyReplacement=true` (kube-proxy disabled in the kind config, so Cilium owns service-VIP redirection via its own `cgroup/connect4` program). Validates that our `cgroup/connect4` and Cilium's coexist under multi-attach: both programs load and attach via `BPF_LINK_CREATE`, the kernel runs both per connect, and the e2e relies on both being functional simultaneously (apiserver ClusterIP traffic depends on Cilium's program; metadata-IP traffic depends on ours; if either program were broken the e2e would fail in obvious ways). The two act on disjoint destinations (ClusterIP range vs `169.254.169.254`), so order between them is not load-bearing — that's a property of our narrow rewrite, not luck.
- `kindnet` — kind's default CNI, default kube-proxy. Validates the README's "no specific CNI required" claim by exercising the full attestation chain on a non-Cilium cluster.

`fail-fast: false` so a flake or genuine bug in one entry doesn't mask the others.

**Drop OCI artifacts from PR validation.** Container images, the helm chart, and the timoni module no longer go through GHCR for PR runs:

- `make build` / `make build-go-test` use `docker buildx --load` instead of `--push`. Local single-platform image (linux/amd64), tagged `gke-metadata-server-test:container` / `:go-test`.
- New `make kind-load-images` runs `kind load docker-image` to make the local images available to the cluster's containerd.
- `main_test.go` applies helm/timoni from the on-disk paths (`./helm/gke-metadata-server`, `./timoni/gke-metadata-server`); no `helm pull` or `timoni mod push` / `timoni apply oci://...`.
- Pods reference images by tag with `imagePullPolicy: Never`. The `<CONTAINER_DIGEST>` / `<GO_TEST_DIGEST>` / `<HELM_VERSION>` machinery is gone; `<LOCAL_IMAGE>` / `<LOCAL_TAG_DAEMON>` / `<LOCAL_TAG_GOTEST>` placeholders take their place.
- `version.txt` lifecycle removed for PR. Helm chart version is hardcoded `0.0.0-dev` (only consumed as a metadata label since we apply from filesystem).

This eliminates the OCI-tag race that would otherwise affect parallel matrix entries pushing to the same registry namespace, and removes a few minutes of upload/pull latency from each CI run. The release workflow is **untouched** — it has its own inline OCI publishing path against the production registry namespace.

## Build → cluster → load → test ordering

The pipeline order in the workflow is intentional:

1. `make ci-cluster CNI=...` — kind cluster + GCP workload-identity provider.
2. `make build` — local docker build of daemon image (~30-60s).
3. `make build-go-test` — local docker build of test image (~30-60s).
4. `make kind-load-images` — `kind load docker-image` for both.
5. `make ci-test` — unit + e2e.

Steps 2-4 collectively act as the GCP workload-identity-provider propagation buffer (IAM is eventually consistent; tests issuing token exchanges immediately after provider creation have flaked in the past). The previous design relied incidentally on the same buffer via the `docker buildx --push` step.

## A flake fixed along the way

`cloud.google.com/go/compute/metadata`'s `OnGCE()` runs two strategies in parallel — an HTTP probe to `169.254.169.254/` checking for `Metadata-Flavor: Google` in the response, and a DNS lookup for `metadata.google.internal` — and returns whichever finishes first. On eBPF nodes, the `--test-proxy-upstream` marker server (added in #489 to e2e-test the proxy passthrough) intercepts non-metadata requests on `169.254.169.254` and replies without the Google flavor header, so when the HTTP probe wins the race, `OnGCE` returns false and every Google-library call fails with "could not find default credentials." The library short-circuits to `true` if `GCE_METADATA_HOST` is set, so this PR sets it on all eBPF and Loopback test pods (None mode already sets it for routing reasons).

## Files

- `Makefile` — `build` / `build-go-test` go local; new `kind-load-images`; `cluster` and `install-cilium` parameterized by `CNI`.
- `testdata/kind-cilium-kpr.yaml`, `testdata/kind-kindnet.yaml` — new kind configs per CNI.
- `testdata/helm.yaml`, `testdata/timoni*.cue`, `testdata/pod.yaml` — switched to local image refs + `pullPolicy: Never`.
- `main_test.go` — drops digest reads and `helm pull` / `timoni mod push` flow; applies from on-disk paths; sets `GCE_METADATA_HOST` on eBPF/Loopback pods.
- `.github/workflows/pull-request.yaml` — adds matrix axis, drops `packages: write` permission (no GHCR push), drops the per-run `version.txt` setup.
- `README.md` — drops the "kubeProxyReplacement conflicts with this mode" claim (CI now validates the opposite); the compatibility section lists the three CI-validated configurations.
- `.github/workflows/release.yaml` and `.github/actions/ci-setup/action.yaml` — **untouched.** Release flow continues to push multi-platform images, sign with cosign, etc.

## Test plan

- [x] All three matrix entries pass on CI
- [x] kindnet passing confirms the "no specific CNI required" README claim
- [x] cilium-kpr passing confirms multi-attach coexistence with Cilium's own `cgroup/connect4`
