### PR TITLE
Serve root path with Metadata-Flavor: Google so ADC detects GCE

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -103,10 +103,11 @@ jobs:
     # Pipeline order is intentional:
     #   ci-cluster (kind + GCP provider) → build (local docker image, ~30-60s,
     #   acts as the GCP-propagation buffer) → build-go-test (same) →
+    #   build-pytest (Python image for the DNS test pods) →
     #   kind-load-images → ci-test. Container images are built locally and
     #   loaded into kind's containerd; nothing is pushed to a registry for
     #   PR validation.
-    - run: make gen-ebpf ci-cluster build build-go-test kind-load-images ci-test
+    - run: make gen-ebpf ci-cluster build build-go-test build-pytest kind-load-images ci-test
       env:
         PLATFORMS: linux/amd64
         CNI: ${{ matrix.cni }}

--- a/Dockerfile.pytest
+++ b/Dockerfile.pytest
@@ -1,0 +1,14 @@
+# Copyright 2026 Matheus Pimenta.
+# SPDX-License-Identifier: AGPL-3.0
+
+# Prebuilt image for the Python DNS test pods. google-auth is baked in at build
+# time so the pods never fetch from PyPI at runtime.
+FROM python:3.13-slim@sha256:b04b5d7233d2ad9c379e22ea8927cd1378cd15c60d4ef876c065b25ea8fb3bf3
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir google-auth==2.53.0 requests==2.32.3
+
+COPY testdata/python_probe.py ./python_probe.py
+
+CMD [ "python", "/app/python_probe.py" ]

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ export CNI
 LOCAL_IMAGE := gke-metadata-server-test
 LOCAL_TAG_DAEMON := container
 LOCAL_TAG_GOTEST := go-test
+LOCAL_TAG_PYTEST := python-test
 # Helm/Timoni need a valid SemVer for chart/module metadata; the value is
 # only used as a string label in PR-mode applies (filesystem-based, not OCI).
 LOCAL_VERSION := 0.0.0-dev
@@ -21,7 +22,7 @@ PLATFORMS ?= linux/amd64
 CILIUM_VERSION ?= 1.19.4
 
 .PHONY: dev
-dev: tidy gen-ebpf dev-cluster build build-go-test kind-load-images dev-test
+dev: tidy gen-ebpf dev-cluster build build-go-test build-pytest kind-load-images dev-test
 
 .PHONY: clean
 clean:
@@ -169,6 +170,14 @@ build-go-test:
 	mv .dockerignore .dockerignore.test
 	mv .dockerignore.bkp .dockerignore
 
+.PHONY: build-pytest
+# Builds the Python test image with google-auth baked in. Used by the
+# test-python-dns and test-python-no-dns pods to prove the google-auth hostname
+# fetch needs DNS resolution of metadata.google.internal.
+build-pytest:
+	docker buildx build . --platform ${PLATFORMS} \
+		-t ${LOCAL_IMAGE}:${LOCAL_TAG_PYTEST} -f Dockerfile.pytest --load
+
 .PHONY: kind-load-images
 # Loads the locally-built daemon and test images into the kind cluster's
 # containerd. Must run after both `build` and `build-go-test` and after the
@@ -177,6 +186,7 @@ build-go-test:
 kind-load-images:
 	kind load docker-image --name gke-metadata-server ${LOCAL_IMAGE}:${LOCAL_TAG_DAEMON}
 	kind load docker-image --name gke-metadata-server ${LOCAL_IMAGE}:${LOCAL_TAG_GOTEST}
+	kind load docker-image --name gke-metadata-server ${LOCAL_IMAGE}:${LOCAL_TAG_PYTEST}
 
 .PHONY: test-unit
 test-unit:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/matheuscscp/gke-metadata-server
 go 1.26.0
 
 require (
-	cloud.google.com/go/compute/metadata v0.9.0
 	cloud.google.com/go/storage v1.62.1
 	github.com/cilium/ebpf v0.21.0
 	github.com/coreos/go-oidc/v3 v3.18.0
@@ -30,6 +29,7 @@ require (
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.7.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4,10 +4,12 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/matheuscscp/gke-metadata-server/internal/logging"
@@ -101,31 +103,35 @@ func (p *proxy) Close() error {
 }
 
 func (p *proxy) handle(client net.Conn) {
-	// read first line to determine if it's a metadata request
-	var buf []byte
-	matches := true
-	toRead := "GET /computeMetadata/v1"
 	l := logger().WithField("clientAddr", client.RemoteAddr().String())
-	for len(toRead) > 0 {
-		b := make([]byte, len(toRead))
-		n, err := client.Read(b)
+
+	// Sniff the HTTP request line to decide where this connection goes. The
+	// genuine GKE metadata server serves the root path and everything under
+	// /computeMetadata, so those must reach the inner metadata server. The root
+	// probe is what ADC libraries (google-auth ping, the Go SDK testOnGCE) use
+	// to detect GCE, so it cannot be forwarded upstream. Any other request is
+	// proxied through to 169.254.169.254:80 verbatim. We read just enough of
+	// "METHOD PATH HTTP/.." to extract the path, bounded by sniffCap so a slow
+	// or garbage client cannot make us buffer unboundedly.
+	const sniffCap = 8192
+	var buf []byte
+	chunk := make([]byte, 256)
+	for {
+		n, err := client.Read(chunk)
+		buf = append(buf, chunk[:n]...)
+		if requestPathComplete(buf) || len(buf) >= sniffCap {
+			break
+		}
 		if err != nil {
 			l.WithError(err).Error("error reading from client")
 			client.Close()
 			return
 		}
-		buf = append(buf, b[:n]...)
-		if string(toRead[:n]) != string(b[:n]) {
-			// not a metadata request
-			matches = false
-			break
-		}
-		toRead = toRead[n:]
 	}
 	client = &sniffedConn{Conn: client, buf: buf}
 
-	// if it's a metadata request, enqueue it and return
-	if matches {
+	// if it targets the metadata surface, enqueue it for the inner server
+	if isMetadataRequest(buf) {
 		select {
 		case p.queue <- client:
 		case <-p.ctx.Done():
@@ -170,6 +176,39 @@ func (p *proxy) handle(client net.Conn) {
 	}()
 	<-done
 	<-done
+}
+
+// requestPathComplete reports whether buf already contains the full HTTP
+// request path, meaning the second space in "METHOD PATH HTTP/.." has been read
+// or the request line ended, so sniffing can stop.
+func requestPathComplete(buf []byte) bool {
+	if bytes.IndexByte(buf, '\n') >= 0 {
+		return true
+	}
+	sp := bytes.IndexByte(buf, ' ')
+	return sp >= 0 && bytes.IndexByte(buf[sp+1:], ' ') >= 0
+}
+
+// isMetadataRequest reports whether the sniffed request line targets the
+// metadata surface served by the emulator, meaning a GET for the root path or
+// any path under /computeMetadata. This mirrors what the genuine GKE metadata
+// server serves with 200 and the Metadata-Flavor Google header. Any other
+// request is proxied through to the real 169.254.169.254:80 endpoint.
+func isMetadataRequest(buf []byte) bool {
+	const method = "GET "
+	if !bytes.HasPrefix(buf, []byte(method)) {
+		return false
+	}
+	rest := buf[len(method):]
+	sp := bytes.IndexByte(rest, ' ')
+	if sp < 0 {
+		return false
+	}
+	path := string(rest[:sp])
+	if q := strings.IndexByte(path, '?'); q >= 0 {
+		path = path[:q]
+	}
+	return path == "/" || path == "/computeMetadata" || strings.HasPrefix(path, "/computeMetadata/")
 }
 
 func (s *sniffedConn) Read(b []byte) (int, error) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Matheus Pimenta.
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import "testing"
+
+func TestIsMetadataRequest(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		line string
+		want bool
+	}{
+		// Metadata surface, must be served by the inner metadata server.
+		{"root", "GET / HTTP/1.1\r\nHost: metadata\r\n\r\n", true},
+		{"root with query", "GET /?recursive=true HTTP/1.1\r\n\r\n", true},
+		{"computeMetadata no slash", "GET /computeMetadata HTTP/1.1\r\n\r\n", true},
+		{"computeMetadata slash", "GET /computeMetadata/ HTTP/1.1\r\n\r\n", true},
+		{"v1 dir", "GET /computeMetadata/v1/ HTTP/1.1\r\n\r\n", true},
+		{"v1 leaf", "GET /computeMetadata/v1/instance/name HTTP/1.1\r\n\r\n", true},
+		{"v1 token with query", "GET /computeMetadata/v1/instance/service-accounts/default/token?scopes=x HTTP/1.1\r\n\r\n", true},
+
+		// Not metadata, must be proxied through to the real endpoint.
+		{"proxy test path", "GET /_proxy_test HTTP/1.1\r\n\r\n", false},
+		{"aws imds", "GET /latest/meta-data/ HTTP/1.1\r\n\r\n", false},
+		{"computeMetadata prefix lookalike", "GET /computeMetadatax HTTP/1.1\r\n\r\n", false},
+		{"non-GET method", "POST /computeMetadata/v1/x HTTP/1.1\r\n\r\n", false},
+		{"empty", "", false},
+		{"only method", "GET ", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMetadataRequest([]byte(tt.line)); got != tt.want {
+				t.Fatalf("isMetadataRequest(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestPathComplete(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		buf  string
+		want bool
+	}{
+		{"full line", "GET / HTTP/1.1", true},
+		{"two spaces only", "GET /computeMetadata/v1 ", true},
+		{"newline ends line", "GET /\r\n", true},
+		{"method and path no trailing space", "GET /computeMetadata/v1", false},
+		{"only method", "GET ", false},
+		{"empty", "", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := requestPathComplete([]byte(tt.buf)); got != tt.want {
+				t.Fatalf("requestPathComplete(%q) = %v, want %v", tt.buf, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/gke_apis_test.go
+++ b/internal/server/gke_apis_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/storage"
 	"github.com/coreos/go-oidc/v3/oidc"
 	jwt "github.com/golang-jwt/jwt/v5"
@@ -52,12 +51,6 @@ func isDirectAccessPod() bool {
 		return true
 	}
 	return false
-}
-
-func TestOnGCE(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	assert.True(t, metadata.OnGCEWithContext(ctx))
 }
 
 func TestGKEServiceAccountTokenAPI(t *testing.T) {
@@ -232,6 +225,36 @@ func TestProxyPassthrough(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 	assert.Equal(t, proxytest.Marker, resp.Header.Get(proxytest.HeaderName))
+}
+
+// TestOnGCERootProbe exercises the bare "GET /" that ADC client libraries use
+// to detect GCE. google-auth's ping and the Go SDK's testOnGCE both require
+// HTTP 200 with the Metadata-Flavor: Google header on the root path. This is a
+// raw request rather than metadata.OnGCE, so it stays immune to the two masks
+// that hide the failure in the Go library, namely the GCE_METADATA_HOST
+// short-circuit and the metadata.google.internal /etc/hosts DNS fallback. The
+// Python library probes the same way, which is why #501 was reported there
+// first. On eBPF nodes the proxy used to route only "GET /computeMetadata/v1"
+// to the metadata server, so the root probe was forwarded upstream and lost the
+// header. Gated to eBPF nodes via EXPECT_PROXY_UPSTREAM, like
+// TestProxyPassthrough.
+func TestOnGCERootProbe(t *testing.T) {
+	if os.Getenv("EXPECT_PROXY_UPSTREAM") != "true" {
+		t.Skip("EXPECT_PROXY_UPSTREAM not set, pod is not on an eBPF node")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/", nil)
+	require.NoError(t, err)
+	req.Header.Set("Metadata-Flavor", "Google")
+	// Force a fresh TCP connection so the proxy sniffs the request line for
+	// this request instead of reusing a keep-alive connection.
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "Google", resp.Header.Get("Metadata-Flavor"))
 }
 
 func TestGKEServiceAccountIdentityAPI(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,8 @@ type pod struct {
 	serviceAccountName string
 	nodeSelector       map[string]string
 	hostNetwork        bool
+	hostAliases        bool
+	expectDNS          string
 	expectedExitCode   int
 }
 
@@ -37,6 +39,7 @@ var (
 	localImage     = envOrDefault("LOCAL_IMAGE", "gke-metadata-server-test")
 	localTagDaemon = envOrDefault("LOCAL_TAG_DAEMON", "container")
 	localTagGoTest = envOrDefault("LOCAL_TAG_GOTEST", "go-test")
+	localTagPytest = envOrDefault("LOCAL_TAG_PYTEST", "python-test")
 )
 
 func envOrDefault(k, d string) string {
@@ -170,6 +173,28 @@ func TestEndToEnd(t *testing.T) {
 					hostNetwork:        true,
 					nodeSelector: map[string]string{
 						"node.gke-metadata-server.matheuscscp.io/routingMode": "None",
+					},
+				},
+				// Two Python pods proving the google-auth hostname fetch needs
+				// DNS. Both run on the eBPF node, so detection over the IP
+				// succeeds in both. With hostAliases the metadata.google.internal
+				// fetch resolves and succeeds, without it the same fetch fails,
+				// which pins the requirement on DNS rather than on reachability.
+				{
+					name:        "test-python-dns",
+					file:        "pod-python.yaml",
+					hostAliases: true,
+					expectDNS:   "yes",
+					nodeSelector: map[string]string{
+						"node.gke-metadata-server.matheuscscp.io/routingMode": "eBPF",
+					},
+				},
+				{
+					name:      "test-python-no-dns",
+					file:      "pod-python.yaml",
+					expectDNS: "no",
+					nodeSelector: map[string]string{
+						"node.gke-metadata-server.matheuscscp.io/routingMode": "eBPF",
 					},
 				},
 			},
@@ -349,30 +374,14 @@ func applyPods(t *testing.T, pods []pod) {
 		// On pods pinned to eBPF nodes, signal that the daemon's --test-proxy-upstream
 		// marker server is reachable so TestProxyPassthrough can issue a hard
 		// assertion rather than skipping. Pods not pinned to eBPF skip the test.
-		//
-		// Also set GCE_METADATA_HOST so cloud.google.com/go/compute/metadata's
-		// OnGCE short-circuits to true without probing 169.254.169.254 — the
-		// proxy-passthrough marker server intercepts non-metadata requests on
-		// that IP and replies without `Metadata-Flavor: Google`, which races
-		// with the library's parallel DNS strategy and flakes OnGCE to false.
+		// No GCE_METADATA_HOST is set on eBPF or Loopback pods. Both intercept
+		// 169.254.169.254 transparently, so the libraries reach the daemon over
+		// the IP and the detection path is exercised for real.
 		var ebpfEnv string
 		if p.nodeSelector["node.gke-metadata-server.matheuscscp.io/routingMode"] == "eBPF" {
 			ebpfEnv = `
     - name: EXPECT_PROXY_UPSTREAM
-      value: "true"
-    - name: GCE_METADATA_HOST
-      value: "169.254.169.254"`
-		}
-		// Loopback mode binds the daemon directly to 169.254.169.254:80; the
-		// library's HTTP probe to that IP gets a metadata response from the
-		// daemon, but for paths it doesn't recognise (like `/`) it can return
-		// without the expected header and lose the OnGCE race the same way.
-		// Short-circuit it the same way as eBPF.
-		var loopbackEnv string
-		if p.nodeSelector["node.gke-metadata-server.matheuscscp.io/routingMode"] == "Loopback" {
-			loopbackEnv = `
-    - name: GCE_METADATA_HOST
-      value: "169.254.169.254"`
+      value: "true"`
 		}
 		var nodeSelector string
 		if len(p.nodeSelector) > 0 {
@@ -384,12 +393,21 @@ func applyPods(t *testing.T, pods []pod) {
 			}
 			nodeSelector = b.String()
 		}
+		var hostAliases string
+		if p.hostAliases {
+			hostAliases = `  hostAliases:
+  - hostnames: [metadata.google.internal]
+    ip: 169.254.169.254`
+		}
 		pod = strings.ReplaceAll(string(b), "<POD_NAME>", p.name)
 		pod = strings.ReplaceAll(pod, "<SERVICE_ACCOUNT>", serviceAccountName)
 		pod = strings.ReplaceAll(pod, "<HOST_NETWORK>", fmt.Sprint(p.hostNetwork))
+		pod = strings.ReplaceAll(pod, "<HOST_ALIASES>", hostAliases)
 		pod = strings.ReplaceAll(pod, "<LOCAL_IMAGE>", localImage)
 		pod = strings.ReplaceAll(pod, "<LOCAL_TAG_GOTEST>", localTagGoTest)
-		pod = strings.ReplaceAll(pod, "<EXTRA_ENV>", noneRoutingEnv+ebpfEnv+loopbackEnv)
+		pod = strings.ReplaceAll(pod, "<LOCAL_TAG_PYTEST>", localTagPytest)
+		pod = strings.ReplaceAll(pod, "<EXPECT_DNS>", p.expectDNS)
+		pod = strings.ReplaceAll(pod, "<EXTRA_ENV>", noneRoutingEnv+ebpfEnv)
 		pod = strings.ReplaceAll(pod, "<NODE_SELECTOR>", nodeSelector)
 
 		// apply

--- a/testdata/pod-python.yaml
+++ b/testdata/pod-python.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Matheus Pimenta.
+# SPDX-License-Identifier: AGPL-3.0
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: <POD_NAME>
+  namespace: default
+spec:
+  serviceAccountName: <SERVICE_ACCOUNT>
+  restartPolicy: Never
+<HOST_ALIASES>
+  containers:
+  - name: probe
+    image: <LOCAL_IMAGE>:<LOCAL_TAG_PYTEST>
+    imagePullPolicy: Never
+    env:
+    - name: EXPECT_DNS
+      value: "<EXPECT_DNS>"
+<NODE_SELECTOR>

--- a/testdata/pod.yaml
+++ b/testdata/pod.yaml
@@ -38,10 +38,12 @@ metadata:
   namespace: default
 spec:
   serviceAccountName: <SERVICE_ACCOUNT> # Use the ServiceAccount created above.
-  # This DNS record is required because the Google libraries hardcode the metadata server
-  # address as the hostname "metadata.google.internal". Sometimes they also hardcode the
-  # IP address. Sometimes they only hardcode the IP address, in which case this setting
-  # would not be needed. It all depends on what library your Pod is using. Test it!
+  # The Google client libraries run an OnGCE check before fetching credentials.
+  # Outside real GCE that check resolves metadata.google.internal and probes the
+  # metadata IP in parallel and trusts whichever answers first, so the name has to
+  # resolve for detection to stay reliable. hostAliases provides that mapping.
+  # Libraries that reach the server only by IP do not strictly need it, libraries
+  # that default to the hostname (Python google-auth, gcloud) also need it to fetch.
   hostAliases:
   - hostnames: [metadata.google.internal]
     ip: 169.254.169.254

--- a/testdata/python_probe.py
+++ b/testdata/python_probe.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Matheus Pimenta.
+# SPDX-License-Identifier: AGPL-3.0
+
+# Proves that the google-auth Python library needs DNS resolution of
+# metadata.google.internal. Detection (ping) targets the IP and works in both
+# pods. Metadata fetches default to the hostname metadata.google.internal, so
+# they work only when hostAliases maps that name to the metadata IP. EXPECT_DNS
+# selects which outcome this pod asserts.
+
+import os
+import sys
+
+import google.auth.transport.requests as treq
+from google.auth.compute_engine import _metadata
+
+
+def main():
+    expect_dns = os.environ.get("EXPECT_DNS", "")
+    req = treq.Request()
+
+    # Detection probes the IP, so it must succeed regardless of DNS.
+    on_gce = _metadata.ping(req)
+    print(f"ping over the IP        : {on_gce}", flush=True)
+    if not on_gce:
+        print("FAIL: ping over the IP must succeed on a routing node", flush=True)
+        return 1
+
+    # Fetches default to the hostname metadata.google.internal, so they need DNS.
+    fetch_ok = False
+    try:
+        project = _metadata.get(req, "project/project-id")
+        fetch_ok = True
+        print(f"fetch over the hostname : ok, project-id={project}", flush=True)
+    except Exception as e:
+        print(f"fetch over the hostname : failed, {type(e).__name__}: {e}", flush=True)
+
+    if expect_dns == "yes":
+        if fetch_ok:
+            print("PASS: hostAliases present, the hostname fetch works", flush=True)
+            return 0
+        print("FAIL: expected the hostname fetch to succeed with hostAliases", flush=True)
+        return 1
+    if expect_dns == "no":
+        if not fetch_ok:
+            print("PASS: no hostAliases, the hostname fetch fails, DNS is required", flush=True)
+            return 0
+        print("FAIL: expected the hostname fetch to fail without hostAliases", flush=True)
+        return 1
+    print(f"FAIL: EXPECT_DNS must be yes or no, got {expect_dns!r}", flush=True)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
ADC libraries detect GCE by requesting GET / and checking for HTTP 200 with the Metadata-Flavor: Google header. In eBPF routing mode the proxy only routed /computeMetadata/v1 to the metadata server and forwarded the root probe upstream, so is_on_gce returned false. The proxy now routes the root path and everything under /computeMetadata to the metadata server and proxies the rest unchanged. Adds an e2e test for the root probe on eBPF nodes and unit tests for the request classifier. Fixes #501.